### PR TITLE
chore(github): add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Summary
+
+<!-- What does this PR do and why? Keep it short. -->
+
+## Type of change
+
+<!-- Mark the relevant option(s) with an "x". -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Refactor / performance (no functional change)
+- [ ] Documentation
+- [ ] Build / tooling / CI
+
+## Related issues
+
+<!-- Link issues this PR addresses, e.g. "Closes #123". -->
+
+## How was this tested?
+
+<!-- Describe how you verified the change. -->
+
+- macOS version:
+- Xcode version:
+- Steps to reproduce / verify:
+
+## Screenshots / recordings
+
+<!-- For UI changes, add before/after screenshots or a short screen recording. -->
+
+## Checklist
+
+- [ ] The `Docky` scheme builds without new warnings.
+- [ ] I tested the change on macOS 14.0 or later.
+- [ ] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
+- [ ] Commit messages follow the `type(scope): summary` convention used in this repo.
+- [ ] I updated documentation (README, comments) where needed.
+- [ ] My changes are licensed under GPLv3, consistent with the rest of the project.


### PR DESCRIPTION
## Summary

Adds a `.github/pull_request_template.md` so new PRs are pre-populated with a consistent structure.

The template is tailored to Docky:
- Type-of-change checklist matching the repo's `type(scope): summary` commit convention.
- A testing section capturing macOS and Xcode versions (project targets macOS 14+).
- A screenshots/recordings section for this UI-heavy Dock app.
- A checklist covering a clean `Docky` scheme build, Accessibility/Screen Recording permissions, and GPLv3 licensing of contributions.

## How was this tested?

N/A - documentation/tooling only. GitHub will auto-populate this template in the PR description for new PRs.