### PR TITLE
fix(dock-drag): keep drop regions live when shelve mode hides Finder/Trash

### DIFF
--- a/Docky/Views/Tiles/TileContainerView.swift
+++ b/Docky/Views/Tiles/TileContainerView.swift
@@ -1752,14 +1752,25 @@ struct TileContainerView: View {
     }
 
     private func isPointInPinnedDropRegion(_ positionValue: CGFloat) -> Bool {
-        guard let finderFrame = tileFrames["pinned:com.apple.finder"],
-              let trailingBoundaryFrame = tileFrames[pinnedTrailingBoundaryTileID] else {
+        guard let trailingBoundaryFrame = tileFrames[pinnedTrailingBoundaryTileID],
+              let lowerBound = pinnedDropRegionLowerBound else {
             return false
         }
 
-        let lowerBound = projected(point: finderFrame.origin) + projected(size: finderFrame.size)
         let upperBound = projected(point: trailingBoundaryFrame.origin)
         return positionValue >= lowerBound && positionValue <= upperBound
+    }
+
+    /// Leading edge of the pinned drop region. Normally this is the trailing
+    /// edge of the fixed Finder fixture, so drops never land before it. Shelve
+    /// mode can hide the Finder tile, in which case there's nothing to anchor
+    /// against, so fall back to the dock's leading content edge. Without this
+    /// fallback the whole pinned section becomes undroppable (issue #13).
+    private var pinnedDropRegionLowerBound: CGFloat? {
+        if let finderFrame = tileFrames["pinned:com.apple.finder"] {
+            return projected(point: finderFrame.origin) + projected(size: finderFrame.size)
+        }
+        return tileFrames.values.map { projected(point: $0.origin) }.min()
     }
 
     private var pinnedTrailingBoundaryTileID: String {
@@ -1767,10 +1778,21 @@ struct TileContainerView: View {
     }
 
     private func isPointInTrailingDropRegion(_ positionValue: CGFloat) -> Bool {
-        guard let dividerFrame = tileFrames["divider:trailing"],
-              let lastTrailingTileID = previewTrailingTiles.last?.id,
-              let trailingBoundaryFrame = tileFrames[lastTrailingTileID] else {
+        guard let dividerFrame = tileFrames["divider:trailing"] else {
             return false
+        }
+
+        // With trailing tiles present the region spans from the divider's
+        // trailing edge to the last tile's trailing edge. Shelve mode can hide
+        // Trash and leave the trailing section empty, so there's no tile past
+        // the divider to anchor against, and the dock shrinks to content,
+        // leaving no empty space either. Treat the divider tile itself as the
+        // drop target so widgets can still be dropped there (issue #13).
+        guard let lastTrailingTileID = previewTrailingTiles.last?.id,
+              let trailingBoundaryFrame = tileFrames[lastTrailingTileID] else {
+            let lowerBound = projected(point: dividerFrame.origin)
+            let upperBound = projected(point: dividerFrame.origin) + projected(size: dividerFrame.size)
+            return positionValue >= lowerBound && positionValue <= upperBound
         }
 
         let lowerBound = projected(point: dividerFrame.origin) + projected(size: dividerFrame.size)


### PR DESCRIPTION
## Summary

In Shelf Mode, hiding Finder made the entire pinned section of the dock reject drops, so apps could not be rearranged or added. The drop-region hit-tests were anchored to fixture tiles that Shelf Mode deletes:

- `isPointInPinnedDropRegion` used the Finder tile's frame for its lower bound, so when Finder is hidden the guard failed and the whole pinned region returned "no drop."
- `isPointInTrailingDropRegion` required a last trailing tile, so hiding Trash with no widgets present left the trailing section undroppable too.

This PR makes both regions degrade gracefully: the pinned region falls back to the dock's leading content edge when the Finder tile is absent, and the trailing region treats the trailing divider itself as the drop target when the trailing section is empty.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Closes #13

## How was this tested?

- macOS version: Sequoia 15.x (reported on 15.6.1)
- Xcode version: 26.4
- Steps to reproduce / verify:
  1. Enable Shelf Mode, Hide Finder, and Hide Trash.
  2. Drag an existing app left/right in the app area: reorders correctly.
  3. Drag a new app into the app area: inserts at the drop point anywhere along the apps, not just the far right.
  4. Drag a widget onto the (empty) trailing divider: drops there.
  5. Turn Hide Finder back off: normal dragging still works (no regression).

Verified manually against a debug build.

> Known limitation (out of scope): with Finder hidden **and** zero pinned apps, the pinned region still has no space to anchor to. Adding the very first app in that exact configuration is not addressed here.

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [ ] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [ ] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
