### PR TITLE
fix(launchpad): context menus during search and Docky pin toggle for folder items

### DIFF
--- a/Docky/Views/MainWindow/LaunchpadOverlayWindowController.swift
+++ b/Docky/Views/MainWindow/LaunchpadOverlayWindowController.swift
@@ -890,12 +890,10 @@ private struct LaunchpadOverlayView: View {
         )
         .contextMenu {
             switch entry {
-            case .app(let app) where !isSearching:
+            case .app(let app):
                 appContextMenu(for: app)
-            case .folder(let folder) where !isSearching:
+            case .folder(let folder):
                 folderContextMenu(for: folder)
-            default:
-                EmptyView()
             }
         }
     }
@@ -2035,6 +2033,13 @@ private struct ExpandedFolderOverlay: View {
                         }
                     )
                     .contextMenu {
+                        let isPinned = TileStore.shared.isPinned(bundleIdentifier: app.bundleIdentifier)
+                        Button(isPinned ? "Remove from Docky" : "Add to Docky") {
+                            _ = TileStore.shared.setPinnedApp(
+                                bundleIdentifier: app.bundleIdentifier,
+                                pinned: !isPinned
+                            )
+                        }
                         Button("Remove from Folder", role: .destructive) {
                             LaunchpadLayoutService.shared.removeFromFolder(bundleID: app.bundleIdentifier)
                         }


### PR DESCRIPTION
## Summary

Right-click context menus in the Launchpad overlay were suppressed while searching, and apps inside a folder only offered "Remove from Folder". This PR:

- Removes the `!isSearching` guard so app and folder context menus work during search.
- Adds the "Add to Docky" / "Remove from Docky" pin toggle to apps inside Launchpad folders, matching the main grid.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Related issues

<!-- none -->

## How was this tested?

- macOS version: 15 (Darwin 25.5)
- Xcode version: 26.4 SDK
- Steps to reproduce / verify:
  - Open the Launchpad overlay, start typing a search, right-click an app/folder, confirm the menu now appears.
  - Open a folder, right-click an app inside it, confirm "Add to Docky" / "Remove from Docky" appears above "Remove from Folder" and toggles the dock pin.

## Screenshots / recordings

<!-- UI menu change; no screenshot attached. -->

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [ ] I tested the change on macOS 14.0 or later.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
