### PR TITLE
docs: note full Xcode + first-launch setup required to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,32 @@ open Docky.xcodeproj
 Build and run the `Docky` scheme. Swift Package dependencies (Sparkle) resolve
 automatically on first build.
 
+You can also build from the command line:
+
+```sh
+xcodebuild -project Docky.xcodeproj -scheme Docky \
+  -configuration Debug -destination 'platform=macOS' \
+  CODE_SIGNING_ALLOWED=NO build
+```
+
 ### Requirements
 
 - macOS 14.0 (Sonoma) or later
-- Xcode 16 or later to build from source
+- The full **Xcode 16 or later** — the Command Line Tools alone are **not** enough
+  (the build needs `xcodebuild` plus Xcode's bundled components)
+
+> [!NOTE]
+> **First-time Xcode setup.** On a machine where Xcode was just installed, finish
+> its one-time setup before building, or the build fails on a missing toolchain:
+>
+> ```sh
+> sudo xcodebuild -license accept
+> sudo xcodebuild -runFirstLaunch
+> ```
+>
+> Skipping these shows up as `xcode-select: error: tool 'xcodebuild' requires Xcode`,
+> a "command line tools instance" warning, or `A required plugin failed to load …
+> try running 'xcodebuild -runFirstLaunch'`.
 
 ## Documentation
 


### PR DESCRIPTION
Following up from the Reddit thread — starting small with a docs fix. 🙂

The README says "Xcode 16 or later," but setting up on a machine without Xcode I hit a few undocumented steps before the build worked. This adds a short note to **Building from source**:

- full Xcode is required (Command Line Tools alone aren't enough)
- a freshly-installed Xcode needs `sudo xcodebuild -license accept` and `sudo xcodebuild -runFirstLaunch` first
- the exact error strings, so they're searchable
- the command-line build command (it was only in CONTRIBUTING.md)

Docs-only, no code changes. Verified the documented flow ends in a clean `** BUILD SUCCEEDED **` on Xcode 26.6.

Relates to #4.
