### PR TITLE
feat(permissions): request widget-tied permissions lazily via in-widget CTA

### DIFF
--- a/Docky/Services/ActionExecutionService.swift
+++ b/Docky/Services/ActionExecutionService.swift
@@ -120,7 +120,7 @@ final class ActionExecutionService {
             switch permission {
             case .accessibility:
                 PermissionsService.shared.requestAccessibilityPermission(prompt: true)
-            case .finderAutomation, .userFolders, .screenCapture, .location, .systemEventsAutomation:
+            case .finderAutomation, .userFolders, .screenCapture, .location, .systemEventsAutomation, .calendar, .reminders:
                 break
             }
 

--- a/Docky/Services/AppleScriptService.swift
+++ b/Docky/Services/AppleScriptService.swift
@@ -194,7 +194,7 @@ final class AppleScriptService {
                     PermissionsService.shared.updateSystemEventsAutomation(status: .denied)
                 case .accessibility:
                     PermissionsService.shared.refresh()
-                case .userFolders, .screenCapture, .location:
+                case .userFolders, .screenCapture, .location, .calendar, .reminders:
                     break
                 }
             }
@@ -240,7 +240,7 @@ final class AppleScriptService {
             PermissionsService.shared.updateSystemEventsAutomation(status: .granted)
         case .accessibility:
             PermissionsService.shared.refresh()
-        case .userFolders, .screenCapture, .location:
+        case .userFolders, .screenCapture, .location, .calendar, .reminders:
             break
         }
     }

--- a/Docky/Services/CalendarService.swift
+++ b/Docky/Services/CalendarService.swift
@@ -40,6 +40,21 @@ final class CalendarService: ObservableObject {
         authorizationStatus = EKEventStore.authorizationStatus(for: .event)
     }
 
+    /// Docky's tri-state view of calendar access. `.writeOnly` counts as
+    /// not-granted because the widget needs read access to show events.
+    var permissionStatus: PermissionStatus {
+        switch authorizationStatus {
+        case .fullAccess, .authorized:
+            return .granted
+        case .notDetermined:
+            return .notDetermined
+        case .denied, .restricted, .writeOnly:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
     func refresh(force: Bool) {
         if !force,
            let lastRefreshDate,
@@ -59,7 +74,12 @@ final class CalendarService: ObservableObject {
             isLoading = false
             lastErrorDescription = "Calendar read access is needed to show upcoming events."
         case .notDetermined:
-            requestAccessAndRefresh()
+            // Permission is requested lazily from the widget's Enable button,
+            // never automatically on render. Leave the widget in its
+            // call-to-action state until the user opts in.
+            nextEvent = nil
+            upcomingEvents = []
+            isLoading = false
         case .denied, .restricted:
             nextEvent = nil
             upcomingEvents = []
@@ -73,27 +93,14 @@ final class CalendarService: ObservableObject {
         }
     }
 
-    private func requestAccessAndRefresh() {
-        guard !isLoading else {
-            return
+    /// Requests calendar access in response to an explicit user action
+    /// (the widget's Enable button). Loads events immediately on grant.
+    func requestAccess() async -> Bool {
+        let granted = await requestCalendarPermission()
+        if granted {
+            loadNextEvent()
         }
-
-        isLoading = true
-
-        Task { [weak self] in
-            guard let self else { return }
-
-            let granted = await self.requestCalendarPermission()
-            guard granted else {
-                self.nextEvent = nil
-                self.upcomingEvents = []
-                self.isLoading = false
-                self.lastErrorDescription = "Enable Calendar access in Settings to show upcoming events."
-                return
-            }
-
-            self.loadNextEvent()
-        }
+        return granted
     }
 
     private func requestCalendarPermission() async -> Bool {

--- a/Docky/Services/PermissionsService.swift
+++ b/Docky/Services/PermissionsService.swift
@@ -40,6 +40,8 @@ enum Permission: String, CaseIterable, Identifiable {
     case systemEventsAutomation
     case screenCapture
     case location
+    case calendar
+    case reminders
 
     var id: String { rawValue }
 
@@ -51,6 +53,8 @@ enum Permission: String, CaseIterable, Identifiable {
         case .systemEventsAutomation: return "Automation (System Events)"
         case .screenCapture: return "Screen Recording"
         case .location: return "Location"
+        case .calendar: return "Calendar"
+        case .reminders: return "Reminders"
         }
     }
 
@@ -68,6 +72,10 @@ enum Permission: String, CaseIterable, Identifiable {
             return "Grant Screen Recording so Docky can show thumbnail previews for minimized windows. Docky only captures the minimized window itself for its dock tile, and nothing leaves your Mac. macOS may require quitting and reopening Docky after you allow this."
         case .location:
             return "Grant location access so Docky can show local weather in the Weather widget. Your location is used on-device to fetch the forecast and is not stored by Docky."
+        case .calendar:
+            return "Grant Calendar access so the Calendar widget can show your upcoming events. Events are read on-device and never leave your Mac."
+        case .reminders:
+            return "Grant Reminders access so the Reminders widget can show your open tasks. Reminders are read on-device and never leave your Mac."
         }
     }
 
@@ -85,6 +93,10 @@ enum Permission: String, CaseIterable, Identifiable {
             return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
         case .location:
             return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices")
+        case .calendar:
+            return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")
+        case .reminders:
+            return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Reminders")
         }
     }
 
@@ -101,6 +113,23 @@ enum Permission: String, CaseIterable, Identifiable {
         case .screenCapture:
             return true
         case .location:
+            return false
+        case .calendar:
+            return false
+        case .reminders:
+            return false
+        }
+    }
+
+    /// Whether this permission is surfaced during the initial onboarding
+    /// flow. Widget-tied permissions (calendar, reminders, location) are
+    /// requested lazily from the widget itself the first time it renders,
+    /// so they never appear in onboarding; only app-feature permissions do.
+    var appearsInOnboarding: Bool {
+        switch self {
+        case .userFolders, .finderAutomation, .accessibility, .systemEventsAutomation, .screenCapture:
+            return true
+        case .location, .calendar, .reminders:
             return false
         }
     }
@@ -127,6 +156,9 @@ final class PermissionsService: ObservableObject {
     @Published private(set) var location: PermissionStatus = .notDetermined
     @Published private(set) var locationGrantMethod: GrantMethod?
 
+    @Published private(set) var calendar: PermissionStatus = .notDetermined
+    @Published private(set) var reminders: PermissionStatus = .notDetermined
+
     private let dockBookmarkKey = "docky.dockPlistBookmark"
     private let userFoldersBookmarkKey = "docky.userFoldersBookmark"
     private let finderAutomationStatusKey = "docky.finderAutomationStatus"
@@ -149,6 +181,8 @@ final class PermissionsService: ObservableObject {
         case .systemEventsAutomation: return systemEventsAutomation
         case .screenCapture: return screenCapture
         case .location: return location
+        case .calendar: return calendar
+        case .reminders: return reminders
         }
     }
 
@@ -162,6 +196,10 @@ final class PermissionsService: ObservableObject {
 
     var setupPermissions: [Permission] {
         Permission.allCases.filter {
+            guard $0.appearsInOnboarding else {
+                return false
+            }
+
             if hasSkippedPermission($0) {
                 return false
             }
@@ -196,6 +234,8 @@ final class PermissionsService: ObservableObject {
         refreshSystemEventsAutomation()
         refreshScreenCapture()
         refreshLocation()
+        refreshCalendar()
+        refreshReminders()
     }
 
     func markInitialOnboardingCompleted() {
@@ -234,7 +274,17 @@ final class PermissionsService: ObservableObject {
         case .screenCapture:
             return requestScreenCapturePermission()
         case .location:
-            return await WeatherService.shared.requestLocationPermission()
+            let granted = await WeatherService.shared.requestAccess()
+            refreshLocation()
+            return granted
+        case .calendar:
+            let granted = await CalendarService.shared.requestAccess()
+            refreshCalendar()
+            return granted
+        case .reminders:
+            let granted = await RemindersService.shared.requestAccess()
+            refreshReminders()
+            return granted
         case .userFolders:
             return false
         }
@@ -248,7 +298,7 @@ final class PermissionsService: ObservableObject {
         case .systemEventsAutomation:
             UserDefaults.standard.removeObject(forKey: systemEventsAutomationStatusKey)
             refreshSystemEventsAutomation()
-        case .userFolders, .accessibility, .screenCapture, .location:
+        case .userFolders, .accessibility, .screenCapture, .location, .calendar, .reminders:
             break
         }
     }
@@ -386,6 +436,16 @@ final class PermissionsService: ObservableObject {
             location = .denied
             locationGrantMethod = nil
         }
+    }
+
+    private func refreshCalendar() {
+        CalendarService.shared.refreshAuthorizationStatus()
+        calendar = CalendarService.shared.permissionStatus
+    }
+
+    private func refreshReminders() {
+        RemindersService.shared.refreshAuthorizationStatus()
+        reminders = RemindersService.shared.permissionStatus
     }
 
     // MARK: - Full Disk Access probe

--- a/Docky/Services/RemindersService.swift
+++ b/Docky/Services/RemindersService.swift
@@ -42,6 +42,21 @@ final class RemindersService: ObservableObject {
         authorizationStatus = EKEventStore.authorizationStatus(for: .reminder)
     }
 
+    /// Docky's tri-state view of reminders access. `.writeOnly` counts as
+    /// not-granted because the widget needs read access to show tasks.
+    var permissionStatus: PermissionStatus {
+        switch authorizationStatus {
+        case .fullAccess, .authorized:
+            return .granted
+        case .notDetermined:
+            return .notDetermined
+        case .denied, .restricted, .writeOnly:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
     func refresh(force: Bool) {
         if !force,
            let lastRefreshDate,
@@ -60,7 +75,11 @@ final class RemindersService: ObservableObject {
             isLoading = false
             lastErrorDescription = "Reminders read access is needed to show your open tasks."
         case .notDetermined:
-            requestAccessAndRefresh()
+            // Permission is requested lazily from the widget's Enable button,
+            // never automatically on render. Leave the widget in its
+            // call-to-action state until the user opts in.
+            snapshot = nil
+            isLoading = false
         case .denied, .restricted:
             snapshot = nil
             isLoading = false
@@ -96,26 +115,14 @@ final class RemindersService: ObservableObject {
         }
     }
 
-    private func requestAccessAndRefresh() {
-        guard !isLoading else {
-            return
+    /// Requests reminders access in response to an explicit user action
+    /// (the widget's Enable button). Loads reminders immediately on grant.
+    func requestAccess() async -> Bool {
+        let granted = await requestRemindersPermission()
+        if granted {
+            loadReminders()
         }
-
-        isLoading = true
-
-        Task { [weak self] in
-            guard let self else { return }
-
-            let granted = await self.requestRemindersPermission()
-            guard granted else {
-                self.snapshot = nil
-                self.isLoading = false
-                self.lastErrorDescription = "Enable Reminders access in Settings to show your open tasks."
-                return
-            }
-
-            self.loadReminders()
-        }
+        return granted
     }
 
     private func requestRemindersPermission() async -> Bool {

--- a/Docky/Services/WeatherService.swift
+++ b/Docky/Services/WeatherService.swift
@@ -50,6 +50,30 @@ final class WeatherService: NSObject, ObservableObject {
         Self.isAuthorizedStatus(authorizationStatus)
     }
 
+    /// Docky's tri-state view of location access, used by the widget to
+    /// decide between real content and the call-to-action state.
+    var permissionStatus: PermissionStatus {
+        if Self.isAuthorizedStatus(authorizationStatus) {
+            return .granted
+        }
+        switch authorizationStatus {
+        case .notDetermined:
+            return .notDetermined
+        default:
+            return .denied
+        }
+    }
+
+    /// Requests location access in response to an explicit user action
+    /// (the widget's Enable button). Fetches weather immediately on grant.
+    func requestAccess() async -> Bool {
+        let granted = await requestLocationPermission()
+        if granted {
+            refresh(force: true)
+        }
+        return granted
+    }
+
     func requestLocationPermission() async -> Bool {
         refreshAuthorizationStatus()
 
@@ -98,13 +122,10 @@ final class WeatherService: NSObject, ObservableObject {
         case .authorizedAlways:
             requestLocation()
         case .notDetermined:
-            if PermissionsService.shared.hasCompletedInitialOnboarding {
-                snapshot = nil
-                lastErrorDescription = "Enable location in Settings to show local weather."
-            } else {
-                isAwaitingLocation = true
-                locationManager.requestWhenInUseAuthorization()
-            }
+            // Location is requested lazily from the widget's Enable button,
+            // never automatically on render. Leave the widget in its
+            // call-to-action state until the user opts in.
+            snapshot = nil
         case .denied, .restricted:
             snapshot = nil
             lastErrorDescription = "Location access is needed for local weather."

--- a/Docky/Views/PermissionsWindow/PermissionsView.swift
+++ b/Docky/Views/PermissionsWindow/PermissionsView.swift
@@ -334,6 +334,8 @@ struct PermissionsView: View {
             return service.screenCaptureGrantMethod
         case .location:
             return service.locationGrantMethod
+        case .calendar, .reminders:
+            return nil
         }
     }
 
@@ -351,6 +353,10 @@ struct PermissionsView: View {
             return "Open System Settings (Screen Recording)"
         case .location:
             return "Open System Settings (Location Services)"
+        case .calendar:
+            return "Open System Settings (Calendars)"
+        case .reminders:
+            return "Open System Settings (Reminders)"
         }
     }
 
@@ -364,6 +370,10 @@ struct PermissionsView: View {
             return "Request Screen Recording Access"
         case .location:
             return "Request Location Access"
+        case .calendar:
+            return "Request Calendar Access"
+        case .reminders:
+            return "Request Reminders Access"
         case .userFolders, .accessibility:
             return "Request Access"
         }
@@ -448,6 +458,10 @@ struct PermissionsView: View {
             return [Color(red: 0.10, green: 0.70, blue: 0.63), Color(red: 0.07, green: 0.28, blue: 0.45)]
         case .location:
             return [Color(red: 1.00, green: 0.53, blue: 0.40), Color(red: 0.60, green: 0.19, blue: 0.21)]
+        case .calendar:
+            return [Color(red: 0.94, green: 0.32, blue: 0.31), Color(red: 0.55, green: 0.12, blue: 0.14)]
+        case .reminders:
+            return [Color(red: 0.98, green: 0.58, blue: 0.24), Color(red: 0.58, green: 0.28, blue: 0.06)]
         }
     }
 
@@ -465,6 +479,10 @@ struct PermissionsView: View {
             return "rectangle.on.rectangle"
         case .location:
             return "location.circle"
+        case .calendar:
+            return "calendar"
+        case .reminders:
+            return "checklist"
         }
     }
 
@@ -493,6 +511,10 @@ struct PermissionsView: View {
             return "Capture live window previews"
         case .location:
             return "Show local weather in the dock"
+        case .calendar:
+            return "Show upcoming events in the dock"
+        case .reminders:
+            return "Show open tasks in the dock"
         }
     }
 
@@ -508,7 +530,7 @@ struct PermissionsView: View {
             return "automation"
         case .screenCapture:
             return "window-switching"
-        case .location:
+        case .location, .calendar, .reminders:
             return nil
         }
     }

--- a/Docky/Views/SettingsWindow/PermissionsSettingsView.swift
+++ b/Docky/Views/SettingsWindow/PermissionsSettingsView.swift
@@ -15,6 +15,8 @@ struct PermissionsSettingsView: View {
             permissionSection(for: .accessibility)
             permissionSection(for: .screenCapture)
             permissionSection(for: .location)
+            permissionSection(for: .calendar)
+            permissionSection(for: .reminders)
 
             Section {
                 Button("Re-check Permissions") {
@@ -62,7 +64,7 @@ struct PermissionsSettingsView: View {
                         service.openSystemSettings(for: permission)
                     }
 
-                    if permission == .finderAutomation || permission == .accessibility || permission == .screenCapture || permission == .location {
+                    if permission == .finderAutomation || permission == .accessibility || permission == .screenCapture || permission == .location || permission == .calendar || permission == .reminders {
                         requestButton(for: permission)
                     }
 
@@ -79,7 +81,7 @@ struct PermissionsSettingsView: View {
 
     @ViewBuilder
     private func requestButton(for permission: Permission) -> some View {
-        if permission == .finderAutomation || permission == .accessibility || permission == .screenCapture || permission == .location {
+        if permission == .finderAutomation || permission == .accessibility || permission == .screenCapture || permission == .location || permission == .calendar || permission == .reminders {
             Button(buttonTitle(for: permission)) {
                 Task {
                     _ = await service.requestPermission(for: permission)
@@ -129,6 +131,8 @@ struct PermissionsSettingsView: View {
             return service.screenCaptureGrantMethod
         case .location:
             return service.locationGrantMethod
+        case .calendar, .reminders:
+            return nil
         }
     }
 
@@ -140,6 +144,8 @@ struct PermissionsSettingsView: View {
         case .accessibility: return "Request Accessibility Access"
         case .screenCapture: return "Request Screen Recording Access"
         case .location: return "Request Location Access"
+        case .calendar: return "Request Calendar Access"
+        case .reminders: return "Request Reminders Access"
         }
     }
 }

--- a/Docky/Views/Tiles/CalendarWidgetTileView.swift
+++ b/Docky/Views/Tiles/CalendarWidgetTileView.swift
@@ -66,7 +66,11 @@ struct CalendarWidgetTileView: View {
     @ViewBuilder
     private func content(layout: LayoutMetrics, now: Date) -> some View {
         if showsDateVariant {
+            // The date variant only renders the calendar day, which needs no
+            // EventKit access, so it never shows the permission CTA.
             dateOneUp(layout: layout, now: now)
+        } else if calendar.permissionStatus != .granted {
+            permissionCTA(isExpanded: false)
         } else if let event = calendar.nextEvent {
             switch renderedSpan {
             case .one:
@@ -79,6 +83,15 @@ struct CalendarWidgetTileView: View {
         } else {
             emptyState(layout: layout)
         }
+    }
+
+    private func permissionCTA(isExpanded: Bool) -> some View {
+        WidgetPermissionCTAView(
+            permission: .calendar,
+            status: calendar.permissionStatus,
+            renderedSpan: renderedSpan,
+            isExpanded: isExpanded
+        )
     }
 
     private func dateOneUp(layout: LayoutMetrics, now: Date) -> some View {
@@ -177,7 +190,9 @@ struct CalendarWidgetTileView: View {
 
     @ViewBuilder
     private func expandedContent(layout: ExpandedLayoutMetrics, now: Date) -> some View {
-        if calendar.upcomingEvents.isEmpty {
+        if calendar.permissionStatus != .granted {
+            permissionCTA(isExpanded: true)
+        } else if calendar.upcomingEvents.isEmpty {
             expandedEmpty(layout: layout, now: now)
         } else {
             expandedAgenda(layout: layout, now: now)

--- a/Docky/Views/Tiles/RemindersWidgetTileView.swift
+++ b/Docky/Views/Tiles/RemindersWidgetTileView.swift
@@ -46,7 +46,14 @@ struct RemindersWidgetTileView: View {
 
     @ViewBuilder
     private func content(layout: LayoutMetrics, now: Date) -> some View {
-        if let nextItem = reminders.snapshot?.primaryItem {
+        if reminders.permissionStatus != .granted {
+            WidgetPermissionCTAView(
+                permission: .reminders,
+                status: reminders.permissionStatus,
+                renderedSpan: renderedSpan,
+                isExpanded: isExpanded
+            )
+        } else if let nextItem = reminders.snapshot?.primaryItem {
             switch renderedSpan {
             case .one:
                 oneUp(item: nextItem, layout: layout, now: now)

--- a/Docky/Views/Tiles/WeatherWidgetTileView.swift
+++ b/Docky/Views/Tiles/WeatherWidgetTileView.swift
@@ -66,7 +66,9 @@ struct WeatherWidgetTileView: View {
 
     @ViewBuilder
     private func content(layout: LayoutMetrics) -> some View {
-        if let snapshot = weather.snapshot {
+        if weather.permissionStatus != .granted {
+            permissionCTA(isExpanded: false)
+        } else if let snapshot = weather.snapshot {
             switch renderedSpan {
             case .one:
                 oneUp(snapshot: snapshot, layout: layout)
@@ -82,11 +84,23 @@ struct WeatherWidgetTileView: View {
 
     @ViewBuilder
     private func expandedContent(layout: ExpandedLayoutMetrics) -> some View {
-        if let snapshot = weather.snapshot {
+        if weather.permissionStatus != .granted {
+            permissionCTA(isExpanded: true)
+        } else if let snapshot = weather.snapshot {
             expandedView(snapshot: snapshot, layout: layout)
         } else {
             expandedPlaceholder(layout: layout)
         }
+    }
+
+    private func permissionCTA(isExpanded: Bool) -> some View {
+        WidgetPermissionCTAView(
+            permission: .location,
+            status: weather.permissionStatus,
+            renderedSpan: renderedSpan,
+            isExpanded: isExpanded,
+            foreground: .white
+        )
     }
 
     private func expandedView(snapshot: WeatherSnapshot, layout: ExpandedLayoutMetrics) -> some View {

--- a/Docky/Views/Tiles/WidgetPermissionCTAView.swift
+++ b/Docky/Views/Tiles/WidgetPermissionCTAView.swift
@@ -1,0 +1,124 @@
+//
+//  WidgetPermissionCTAView.swift
+//  Docky
+//
+
+import SwiftUI
+
+/// Call-to-action shown in place of a widget's content while its underlying
+/// permission is missing. Widget-tied permissions (calendar, reminders,
+/// location) are never requested automatically on render. The OS prompt
+/// fires only when the user taps this view's button. Only the button is
+/// interactive; the rest of the tile stays inert.
+///
+/// The layout adapts to the available size: at 1-up / thumbnail scale it
+/// collapses to icon + button, and at wider spans (or when expanded) it also
+/// shows a one-line reason.
+struct WidgetPermissionCTAView: View {
+    let permission: Permission
+    /// Either `.notDetermined` (button fires the OS prompt) or `.denied`
+    /// (macOS won't re-prompt, so the button deep-links to System Settings).
+    let status: PermissionStatus
+    let renderedSpan: TileSpan
+    var isExpanded: Bool = false
+    /// Foreground colour for the icon/text. Weather draws on a coloured
+    /// gradient (white); calendar/reminders draw on the window background
+    /// (primary).
+    var foreground: Color = .primary
+
+    @ObservedObject private var permissions = PermissionsService.shared
+
+    private var showsReason: Bool {
+        isExpanded || renderedSpan != .one
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let minSide = max(min(proxy.size.width, proxy.size.height), 1)
+            let iconSize = min(max(minSide * (isExpanded ? 0.16 : 0.24), 16), isExpanded ? 40 : 30)
+            let reasonSize = min(max(minSide * 0.11, 10), 14)
+            let spacing = min(max(minSide * 0.06, 4), 12)
+
+            VStack(spacing: spacing) {
+                Image(systemName: iconName)
+                    .font(.system(size: iconSize, weight: .semibold))
+                    .foregroundStyle(foreground.opacity(0.92))
+                    .symbolRenderingMode(.hierarchical)
+
+                if showsReason {
+                    Text(reasonText)
+                        .font(.system(size: reasonSize, weight: .medium))
+                        .foregroundStyle(foreground.opacity(0.72))
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Button {
+                    performAction()
+                } label: {
+                    Text(buttonTitle)
+                        .font(.system(size: reasonSize, weight: .semibold))
+                        .foregroundStyle(foreground.opacity(0.85))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .padding(.horizontal, reasonSize * 0.9)
+                        .padding(.vertical, reasonSize * 0.5)
+                        .background(
+                            Capsule().fill(foreground.opacity(0.16))
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(min(max(minSide * 0.1, 8), 20))
+            .frame(width: proxy.size.width, height: proxy.size.height)
+        }
+    }
+
+    private func performAction() {
+        switch status {
+        case .denied:
+            permissions.openSystemSettings(for: permission)
+        case .notDetermined, .granted:
+            Task {
+                _ = await permissions.requestPermission(for: permission)
+            }
+        }
+    }
+
+    private var buttonTitle: String {
+        switch status {
+        case .denied:
+            return "Open Settings"
+        case .notDetermined, .granted:
+            return enableTitle
+        }
+    }
+
+    private var enableTitle: String {
+        switch permission {
+        case .location: return "Enable Location"
+        case .calendar: return "Enable Calendar"
+        case .reminders: return "Enable Reminders"
+        default: return "Enable Access"
+        }
+    }
+
+    private var reasonText: String {
+        switch permission {
+        case .location: return "Show local weather in the dock."
+        case .calendar: return "Show your upcoming events."
+        case .reminders: return "Show your open tasks."
+        default: return permission.explanation
+        }
+    }
+
+    private var iconName: String {
+        switch permission {
+        case .location: return "location.fill"
+        case .calendar: return "calendar"
+        case .reminders: return "checklist"
+        default: return "lock.fill"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Widget-tied system permissions (Calendar, Reminders, Location) are now requested lazily, only when the user taps an in-widget "Enable" button, instead of being prompted up front during onboarding or automatically on first render. Browsing the widget palette no longer triggers any permission prompt.

- `ensureFresh…()` (called from each widget's `.task`) is now prompt-free: it loads data when granted, otherwise leaves the widget showing a call-to-action card.
- New reusable `WidgetPermissionCTAView` (adaptive by span/expansion) whose button fires the OS prompt while `notDetermined` and deep-links to System Settings once `denied`.
- `.calendar` and `.reminders` are now first-class `Permission` cases (like `.location`), routed through `PermissionsService.requestPermission(for:)` and shown in Settings → Permissions.
- New `appearsInOnboarding` flag keeps all three widget permissions out of the onboarding gate; Location no longer appears in onboarding.
- Removed the old auto-request paths (`requestAccessAndRefresh`) and the onboarding-coupled branch in `WeatherService`.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / performance (no functional change)

## Related issues

<!-- None -->

## How was this tested?

- macOS version: 26.5.1
- Xcode version: Xcode 26.4
- Steps to reproduce / verify:
  1. `tccutil reset Calendar gt.quintero.Docky` and `tccutil reset Reminders gt.quintero.Docky`, then launch Docky.
  2. Confirmed the Calendar and Reminders widgets render the Enable CTA card instead of prompting on launch.
  3. Opened the dock editor palette and confirmed no permission prompt fires while browsing.
  4. Tapped Enable, granted access, and confirmed the widget swaps to real content.
  5. Verified button label color matches the widget body (white on Weather's gradient, primary on Calendar/Reminders).
  6. `Docky` scheme builds cleanly (Debug).

## Screenshots / recordings

<!-- TODO: add before/after of the Calendar/Reminders CTA state -->

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [ ] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
