### PR TITLE
fix(dock): stop autohide from stale fullscreen bounds after Mission Control

### DIFF
--- a/Docky/Views/MainWindow/MainWindow.swift
+++ b/Docky/Views/MainWindow/MainWindow.swift
@@ -441,6 +441,7 @@ final class MainWindow: NSPanel {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateFullscreenStateAndApply(animated: true)
+                self?.scheduleFullscreenRecheck()
             }
             .store(in: &cancellables)
     }
@@ -1023,7 +1024,7 @@ final class MainWindow: NSPanel {
         let ownPID = ProcessInfo.processInfo.processIdentifier
         let frame = screen.frame
         let visibleFrame = screen.visibleFrame
-        var foundFullscreen = false
+        var fullscreenCandidate = false
         var foundMaximized = false
 
         for info in windows {
@@ -1051,15 +1052,31 @@ final class MainWindow: NSPanel {
             // the menubar area). Maximized: window matches visibleFrame
             // exactly, which is smaller than frame by the menubar.
             if Self.rect(nsBounds, matches: frame) {
-                foundFullscreen = true
+                fullscreenCandidate = true
             } else if Self.rect(nsBounds, matches: visibleFrame) {
                 foundMaximized = true
             }
 
-            if foundFullscreen && foundMaximized { break }
+            if fullscreenCandidate && foundMaximized { break }
         }
 
+        let foundFullscreen = fullscreenCandidate
+            && registryReportsFullscreenWindow(matching: frame, primaryScreenHeight: primaryScreenHeight)
+
         return ContentOverlapObservation(isFullscreen: foundFullscreen, isMaximized: foundMaximized)
+    }
+
+    private func registryReportsFullscreenWindow(matching frame: CGRect, primaryScreenHeight: CGFloat) -> Bool {
+        WindowRegistry.shared.windows.contains { window in
+            guard !window.isMinimized, let axFrame = window.frame else { return false }
+            let nsFrame = CGRect(
+                x: axFrame.minX,
+                y: primaryScreenHeight - axFrame.maxY,
+                width: axFrame.width,
+                height: axFrame.height
+            )
+            return Self.rect(nsFrame, matches: frame, tolerance: 2)
+        }
     }
 
     private static func rect(_ a: CGRect, matches b: CGRect, tolerance: CGFloat = 1) -> Bool {


### PR DESCRIPTION
## Summary
Fixes #20. With "Autohide Window" off and "Hide in Fullscreen" on, the dock would hide after exiting Mission Control into a different window (or switching desktops), even though nothing was fullscreen. It only reappeared after touching the window.

## Cause
`CGWindowList` bounds go stale after a Mission Control / Space transition: the window you land on is reported at full-screen bounds until it's next interacted with, tripping the fullscreen check and hiding the dock.

## Fix
- Confirm a `CGWindowList` fullscreen match against `WindowRegistry`'s accessibility-reported frames, which don't carry the stale bounds. Fail-safe direction is "leave the dock visible."
- Schedule a `scheduleFullscreenRecheck()` after `didActivateApplicationNotification` so a transient false positive self-corrects.

## Testing
- Builds clean.
- On-device: disable "Autohide Window", enable "Hide in Fullscreen", open Mission Control, switch to a different window / desktop; dock stays put. Genuine fullscreen still hides the dock.