### PR TITLE
fix(icons): render app icons sharp instead of upscaling the 32pt representation

### DIFF
--- a/Docky/Services/IconCacheService.swift
+++ b/Docky/Services/IconCacheService.swift
@@ -20,7 +20,34 @@ final class IconCacheService {
         return cache
     }()
 
+    /// Nominal point size stamped onto every icon fetched from LaunchServices.
+    /// `NSWorkspace.icon(forFile:)` returns a multi-representation image whose
+    /// logical `size` is only 32x32, so `Image(nsImage:).resizable()` rasterizes
+    /// at that nominal size and then upscales it into the tile — which is what
+    /// made icons look blurry next to the native Dock (the native Dock draws
+    /// straight from the 512px representation). Stamping a large nominal size
+    /// makes SwiftUI select a high-resolution representation and downsample it
+    /// instead. The representations stay lazy, so this does not eagerly allocate
+    /// a bitmap per icon.
+    ///
+    /// 256 is the smallest standard `.icns` representation that still covers the
+    /// largest size a tile is ever drawn at (a magnified tile tops out around
+    /// ~192px), so every dock surface downsamples rather than upscales. Going
+    /// higher (512/1024) would decode a source bitmap 4x larger for no visible
+    /// gain in the dock and extra per-frame resampling work during magnification.
+    private static let normalizedIconExtent: CGFloat = 256
+
     private init() {}
+
+    /// Fetches an icon from LaunchServices and normalizes its nominal size so
+    /// downstream `resizable()` rendering downsamples a high-resolution
+    /// representation rather than upscaling the default 32pt one. See
+    /// `normalizedIconExtent`.
+    private static func workspaceIcon(forFile path: String) -> NSImage {
+        let image = NSWorkspace.shared.icon(forFile: path)
+        image.size = NSSize(width: normalizedIconExtent, height: normalizedIconExtent)
+        return image
+    }
 
     func icon(forBundleIdentifier bundleIdentifier: String) -> NSImage {
         let key = "bundle:\(bundleIdentifier)" as NSString
@@ -48,7 +75,7 @@ final class IconCacheService {
         return await Task.detached(priority: .userInitiated) { [cache] in
             let image: NSImage
             if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
-                image = NSWorkspace.shared.icon(forFile: url.path)
+                image = Self.workspaceIcon(forFile: url.path)
             } else {
                 image = NSImage(systemSymbolName: "app.fill", accessibilityDescription: nil) ?? NSImage()
             }
@@ -60,14 +87,14 @@ final class IconCacheService {
     func icon(forFileURL url: URL) -> NSImage {
         let key = "path:\(url.path)" as NSString
         if let cached = cache.object(forKey: key) { return cached }
-        let image = NSWorkspace.shared.icon(forFile: url.path)
+        let image = Self.workspaceIcon(forFile: url.path)
         cache.setObject(image, forKey: key)
         return image
     }
 
     func preloadIcon(forBundleIdentifier bundleIdentifier: String, fileURL: URL) {
         let key = "bundle:\(bundleIdentifier)" as NSString
-        cache.setObject(NSWorkspace.shared.icon(forFile: fileURL.path), forKey: key)
+        cache.setObject(Self.workspaceIcon(forFile: fileURL.path), forKey: key)
     }
 
     func previewIcon(forFileURL url: URL) -> NSImage {
@@ -94,7 +121,7 @@ final class IconCacheService {
 
     private func loadIcon(forBundleIdentifier bundleIdentifier: String) -> NSImage {
         if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
-            return NSWorkspace.shared.icon(forFile: url.path)
+            return Self.workspaceIcon(forFile: url.path)
         }
         return NSImage(systemSymbolName: "app.fill", accessibilityDescription: nil) ?? NSImage()
     }


### PR DESCRIPTION
## Summary

App icons rendered noticeably blurrier than the native Dock. Every icon flows through `IconCacheService`, which caches the result of `NSWorkspace.icon(forFile:)` as-is. That image carries high-resolution representations (128/256/512) but its *nominal* `size` is only 32×32pt. SwiftUI's `Image(nsImage:).resizable()` snapshots the image at its nominal size and then upscales that 32px raster into the tile (46–92px), which is the blur. `NSImageView`/the native Dock avoid this by re-picking the best representation at draw time.

Fix: route all LaunchServices fetches through a helper that stamps a 256×256 nominal size on the returned image. This steers SwiftUI to snapshot from the 256px representation and *downsample* into the tile (sharp) instead of upscaling the 32px one. Representations stay lazy, so nothing is eagerly rasterized; the added cost is the decoded source rep (~256KB/icon, bounded by the existing 256-image cache).

256 is deliberate: it's the smallest standard `.icns` representation that still covers the largest size a tile is ever drawn at (magnified tiles top out ~192px), so every dock surface downsamples. Going to 512/1024 would decode a 4× larger source for no visible dock gain and extra per-frame resampling during magnification.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Closes #19

## How was this tested?

- macOS version: 26.x (repro reported on 26.4 / 26.5, non-Retina external display where it's most visible)
- Xcode version: 17.x
- Steps to reproduce / verify:
  - `xcodebuild -scheme Docky -configuration Debug build` succeeds with no new warnings.
  - Launch Docky and compare app icons (Notion, Discord, etc.) against the native Dock at the same tile size.
  - Most visible on a 1× (non-Retina) display and on detailed icons.

## Screenshots / recordings

_Pending on-device before/after capture on a 1× display._

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [ ] I tested the change on macOS 14.0 or later.
- [ ] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
