### PR TITLE
feat(folders): show per-app running indicators in the app folder grid

### DIFF
--- a/Docky/Views/Tiles/AppFolderTileView.swift
+++ b/Docky/Views/Tiles/AppFolderTileView.swift
@@ -361,6 +361,7 @@ struct AppFolderPopoverView: View {
     let onPopoverSizeChange: (CGSize) -> Void
     @Bindable private var preferences = DockyPreferences.shared
     @ObservedObject private var dockBadges = DockBadgeService.shared
+    @ObservedObject private var workspace = WorkspaceService.shared
     @State private var isEditingTitle = false
     @State private var editingTitle = ""
     @State private var isTitleHovered = false
@@ -528,6 +529,9 @@ struct AppFolderPopoverView: View {
             .aspectRatio(contentMode: .fit)
             .frame(width: Self.itemWidth, height: Self.itemHeight)
             .padding(overrideIconPadding(for: app.bundleIdentifier, side: Self.itemWidth))
+            .overlay(alignment: .bottom) {
+                runningIndicator(for: app.bundleIdentifier)
+            }
             // The opened folder always shows the real per-app count,
             // regardless of the tile's combined/per-app preference — these
             // icons are full size, so the number is always legible.
@@ -537,6 +541,17 @@ struct AppFolderPopoverView: View {
                     DockBadgeView(text: badge)
                 }
             }
+    }
+
+    @ViewBuilder
+    private func runningIndicator(for bundleIdentifier: String) -> some View {
+        if preferences.effectiveActiveIndicatorShape != .none,
+           workspace.isRunning(bundleIdentifier: bundleIdentifier) {
+            Circle()
+                .fill(Color(nsColor: preferences.effectiveActiveIndicatorColor).opacity(0.9))
+                .frame(width: 6, height: 6)
+                .offset(y: 3)
+        }
     }
 
     private func handleReorderChange(bundleIdentifier: String, value: DragGesture.Value) {


### PR DESCRIPTION
## Summary

App folders now show a per-app running indicator inside the opened popover grid. Each app in the folder that is currently running gets a small dot under its icon, so an opened folder reads as a live workspace at a glance. The dot uses the dock's configured active-indicator color and is hidden entirely when the user has running indicators turned off.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [ ] Documentation
- [ ] Build / tooling / CI

## Related issues

<!-- none -->

## How was this tested?

- macOS version: 15 (Sequoia)
- Xcode version: 16
- Steps to reproduce / verify:
  1. Build and run the `Docky` scheme.
  2. Create an app folder in the dock (drag one app onto another) containing a mix of running and non-running apps.
  3. Open the folder to show the grid popover.
  4. Confirm running apps show a dot under their icon and non-running apps do not.
  5. Launch/quit an app while the popover is open and confirm the dots update live.
  6. Set the active indicator shape to "None" and confirm no dots appear.

## Screenshots / recordings

<!-- Add before/after of an opened app folder. -->

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [ ] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [ ] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.