### PR TITLE
chore(funding): add GitHub Sponsors and Buy Me a Coffee funding setup

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: josejuanqm
+buy_me_a_coffee: josejuanqm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,12 @@
 Thanks for your interest in improving Docky. Contributions of all kinds are
 welcome: bug reports, fixes, features, and documentation.
 
+## Community
+
+Join the [Docky Discord](https://discord.gg/vAwVNtPSgE) to ask questions, share
+widgets, and follow development. [Sponsors](https://github.com/sponsors/josejuanqm)
+get a supporter role there.
+
 ## Reporting issues
 
 Open an issue at https://github.com/josejuanqm/docky/issues. Helpful reports

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ custom icons, and scripted actions.
 [![Platform](https://img.shields.io/badge/macOS-14%2B-black?logo=apple)](https://getdocky.com)
 [![Universal](https://img.shields.io/badge/Apple%20Silicon%20%26%20Intel-Universal-orange)](https://getdocky.com)
 [![Website](https://img.shields.io/badge/getdocky.com-Download-brightgreen)](https://getdocky.com)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/josejuanqm)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/josejuanqm)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/vAwVNtPSgE)
 
 [**Download**](https://getdocky.com) &nbsp;·&nbsp; [**Website**](https://getdocky.com) &nbsp;·&nbsp; [**Build from source**](#building-from-source)
 
@@ -129,6 +132,20 @@ automatically on first build.
 
 - [External widget bundles](docs/external-widgets.md): the `.dockywidget` bundle
   contract and how to build community widgets.
+
+## Supporting Docky
+
+Docky is free and open source with no paid tier. If it earns a place in your
+Dock, you can help fund ongoing development:
+
+- **[GitHub Sponsors](https://github.com/sponsors/josejuanqm)**: one-time or
+  monthly, with tiers from ☕ Coffee to ❤️ Patron.
+- **[Buy Me a Coffee](https://buymeacoffee.com/josejuanqm)**: a quick one-off
+  thank-you.
+
+Sponsors also get a supporter role in the [Docky Discord](https://discord.gg/vAwVNtPSgE).
+Supporters are credited in [SUPPORTERS.md](SUPPORTERS.md); sponsoring teams can
+have their logo featured there. Every bit helps keep Docky maintained and free.
 
 ## Dependencies
 

--- a/SUPPORTERS.md
+++ b/SUPPORTERS.md
@@ -1,0 +1,27 @@
+# Supporters
+
+Docky is free and open source, and it stays that way thanks to the people and
+companies who choose to support its development. Thank you. ❤️
+
+Support Docky via [GitHub Sponsors](https://github.com/sponsors/josejuanqm) or
+[Buy Me a Coffee](https://buymeacoffee.com/josejuanqm).
+
+## Sponsors
+
+Companies and teams sponsoring Docky. Your logo and a link to your site go here.
+
+<!-- Add sponsors below, highest tier first:
+- [Company Name](https://example.com)
+-->
+
+_Be the first. Sponsor at the Team / Business tier or above to appear here._
+
+## Backers
+
+Individuals supporting Docky. Thank you for the coffee.
+
+<!-- Add backers below:
+- @github-handle
+-->
+
+_Be the first. Sponsor at any tier to have your name added here._


### PR DESCRIPTION
## Summary

Sets up project funding. Adds `.github/FUNDING.yml` so GitHub renders the Sponsor button (GitHub Sponsors + Buy Me a Coffee), adds a `SUPPORTERS.md` with Sponsors and Backers sections that the sponsorship tiers credit into, and adds sponsor/coffee/Discord badges plus a "Supporting Docky" section to the README. Also adds a Community section to CONTRIBUTING with the Discord invite.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [x] Documentation
- [x] Build / tooling / CI

## Related issues

None.

## How was this tested?

Docs and config only; no app code changed. Verified the funding config, badge links, and Markdown render locally.

- macOS version: n/a
- Xcode version: n/a
- Steps to reproduce / verify: Confirm `.github/FUNDING.yml` parses and links resolve (GitHub Sponsors, Buy Me a Coffee, Discord invite).

## Screenshots / recordings

n/a (no UI change).

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [ ] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
