### PR TITLE
fix(windows): cycle through all windows of the active app

### DIFF
--- a/Docky/Services/WorkspaceService.swift
+++ b/Docky/Services/WorkspaceService.swift
@@ -174,10 +174,8 @@ final class WorkspaceService: ObservableObject {
     }
 
     private func cycleFrontmostAppWindows(_ visibleWindows: [AppWindow]) {
-        // appWindows() returns front-to-back order from AXWindows; raising index 1
-        // promotes the next window beneath the frontmost.
-        guard visibleWindows.count > 1 else { return }
-        _ = focus(window: visibleWindows[1])
+        guard visibleWindows.count > 1, let next = visibleWindows.last else { return }
+        _ = focus(window: next)
     }
 
     private func minimizeAllWindows(_ visibleWindows: [AppWindow]) {


### PR DESCRIPTION
## Summary

Clicking an already-frontmost app with the "When App Is Already Active → Cycle Windows" behavior only ping-ponged between the two most-recent windows and never reached the rest.

`cycleFrontmostAppWindows` focused `visibleWindows[1]`, assuming the list was in front-to-back z-order. It's actually in **MRU order** (`WindowRegistry.bumpWindowToTop` inserts each focused window at index 0), so focusing index 1 bumped that window to index 0 and demoted the old front to index 1. The next click flipped straight back.

Fix: focus the **last** (least-recently-used) visible window. Each click sends the current front to the back of the rotation, so repeated clicks walk through every window in order, and it stays stateless since the MRU registry advances the rotation for us.

`[A,B,C]` → focus C → `[C,A,B]` → focus B → `[B,C,A]` → focus A → `[A,B,C]`

Thanks to @TomMoeras for the diagnosis in the issue. The separate `activate(options:)` suggestion from that thread is left out of scope; it addresses a different symptom (background-process apps) and can be tracked separately.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Closes #41

## How was this tested?

- macOS version: 15 (Darwin 25.5.0)
- Xcode version: current toolchain (`Docky` scheme, Debug)
- Steps to reproduce / verify:
  1. Behavior settings → When App Is Already Active → Cycle Windows.
  2. Open an app with 3+ windows (e.g. Finder) and bring it to front.
  3. Repeatedly click its Docky tile.
  4. Before: it flipped between two windows. After: it rotates through every window in order.

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [ ] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
