### PR TITLE
fix(previews): contained multicolor macwindow placeholder for minimized tiles

### DIFF
--- a/Docky/Views/Tiles/MinimizedWindowTileView.swift
+++ b/Docky/Views/Tiles/MinimizedWindowTileView.swift
@@ -47,9 +47,12 @@ struct MinimizedWindowTileView: View {
                     .clipShape(.rect(cornerRadius: cornerRadius, style: .continuous))
                     .frame(width: cardSize.width - 4, height: cardSize.height - 4)
             } else {
-                Image(systemName: "rectangle.inset.filled")
-                    .font(.system(size: cardSize.height * 0.42, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.75))
+                Image(systemName: "macwindow")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .fontWeight(.medium)
+                    .symbolRenderingMode(.multicolor)
+                    .frame(width: cardSize.width * 0.8, height: cardSize.height * 0.8)
             }
         }
         .frame(width: cardSize.width, height: cardSize.height)


### PR DESCRIPTION
## Summary

When screen recording permission isn't granted (or a capture hasn't populated yet), minimized-window tiles fall back to a placeholder symbol. Swaps `rectangle.inset.filled` for a contained, multicolor `macwindow` glyph sized to 80% of the card.

## Type of change

- [x] Refactor / performance (no functional change)

## How was this tested?

- Built the `Docky` scheme (Debug) and ran the app; placeholder renders as expected.
