### PR TITLE
fix(dock): hide in fullscreen for single-window apps (#34)

### DIFF
--- a/Docky/Services/WindowRegistry.swift
+++ b/Docky/Services/WindowRegistry.swift
@@ -760,6 +760,13 @@ final class WindowRegistry: ObservableObject {
         bumpWindowToTop(element: focusedElement, pid: pid)
     }
 
+    func liveWindows(for pid: pid_t) -> [AppWindow] {
+        guard pid > 0,
+              let app = NSRunningApplication(processIdentifier: pid),
+              app.activationPolicy == .regular else { return [] }
+        return enumerateWindows(for: app)
+    }
+
     private func enumerateWindows(for app: NSRunningApplication) -> [AppWindow] {
         let pid = app.processIdentifier
         guard pid > 0 else { return [] }

--- a/Docky/Views/MainWindow/MainWindow.swift
+++ b/Docky/Views/MainWindow/MainWindow.swift
@@ -1026,12 +1026,13 @@ final class MainWindow: NSPanel {
         let visibleFrame = screen.visibleFrame
         var fullscreenCandidate = false
         var foundMaximized = false
+        var fullscreenCandidatePIDs = Set<pid_t>()
 
         for info in windows {
             guard let layer = info[kCGWindowLayer as String] as? Int, layer == 0 else { continue }
 
-            if let pidNumber = info[kCGWindowOwnerPID as String] as? NSNumber,
-               pidNumber.int32Value == ownPID {
+            let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
+            if ownerPID == ownPID {
                 continue
             }
 
@@ -1053,21 +1054,28 @@ final class MainWindow: NSPanel {
             // exactly, which is smaller than frame by the menubar.
             if Self.rect(nsBounds, matches: frame) {
                 fullscreenCandidate = true
+                if let ownerPID { fullscreenCandidatePIDs.insert(ownerPID) }
             } else if Self.rect(nsBounds, matches: visibleFrame) {
                 foundMaximized = true
             }
-
-            if fullscreenCandidate && foundMaximized { break }
         }
 
         let foundFullscreen = fullscreenCandidate
-            && registryReportsFullscreenWindow(matching: frame, primaryScreenHeight: primaryScreenHeight)
+            && registryReportsFullscreenWindow(
+                candidatePIDs: fullscreenCandidatePIDs,
+                matching: frame,
+                primaryScreenHeight: primaryScreenHeight
+            )
 
         return ContentOverlapObservation(isFullscreen: foundFullscreen, isMaximized: foundMaximized)
     }
 
-    private func registryReportsFullscreenWindow(matching frame: CGRect, primaryScreenHeight: CGFloat) -> Bool {
-        WindowRegistry.shared.windows.contains { window in
+    private func registryReportsFullscreenWindow(
+        candidatePIDs: Set<pid_t>,
+        matching frame: CGRect,
+        primaryScreenHeight: CGFloat
+    ) -> Bool {
+        func fills(_ window: AppWindow) -> Bool {
             guard !window.isMinimized, let axFrame = window.frame else { return false }
             let nsFrame = CGRect(
                 x: axFrame.minX,
@@ -1077,6 +1085,14 @@ final class MainWindow: NSPanel {
             )
             return Self.rect(nsFrame, matches: frame, tolerance: 2)
         }
+
+        for pid in candidatePIDs {
+            if WindowRegistry.shared.liveWindows(for: pid).contains(where: fills) {
+                return true
+            }
+        }
+
+        return WindowRegistry.shared.windows.contains(where: fills)
     }
 
     private static func rect(_ a: CGRect, matches b: CGRect, tolerance: CGFloat = 1) -> Bool {


### PR DESCRIPTION
## Summary
Fixes #34. With "Autohide Window" off and "Hide in Fullscreen" on, the dock stayed visible when a **single-window** app (e.g. Zen Browser) entered fullscreen. Opening a second window of the same app made it work, which was the giveaway.

## Cause
The fullscreen check confirms a `CGWindowList` match against `WindowRegistry`'s accessibility frames (added in #32 to reject stale bounds after Mission Control). But it read the **cached** `WindowRegistry.windows` snapshot. When a lone window enters fullscreen, nothing else triggers a re-enumeration, so the snapshot keeps the pre-fullscreen frame and the match fails. With 2+ windows, the window-count mismatch triggers ScreenCaptureKit reconciliation, which re-enumerates AX and refreshes the frame, so it happened to work.

## Fix
- Add `WindowRegistry.liveWindows(for:)` — a fresh, per-app AX enumeration that bypasses the cached snapshot.
- Record the owning PID(s) of each fullscreen-sized `CGWindowList` match and confirm against a fresh query of those apps, falling back to the cached snapshot only when the fresh query returns nothing.

This keeps #32's protection intact (a fresh AX query of the Mission-Control-landed window returns its real non-fullscreen frame, so the dock stays visible) while fixing #34.

## Testing
- Builds clean.
- Needs on-device confirmation: single Zen window in fullscreen now hides the dock; nothing-fullscreen + Mission Control / desktop switch still keeps the dock visible.