### PR TITLE
fix(widgets): handle photoFrame case in widget settings switches

### DIFF
--- a/Docky/Models/WidgetSettingsSchema.swift
+++ b/Docky/Models/WidgetSettingsSchema.swift
@@ -46,7 +46,7 @@ extension WidgetKind {
         switch self {
         case .weather, .calendar, .nowPlaying:
             true
-        case .calendarDate, .reminders, .batteries, .systemStatus, .search:
+        case .calendarDate, .reminders, .batteries, .systemStatus, .search, .photoFrame:
             false
         case .external(let identifier):
             !(ExternalWidgetRegistry.shared.metadata(for: identifier)?.settingsSchema.isEmpty ?? true)

--- a/Docky/Views/Tiles/Settings/WidgetSettingsView.swift
+++ b/Docky/Views/Tiles/Settings/WidgetSettingsView.swift
@@ -66,7 +66,7 @@ struct WidgetSettingsView: View {
                 tileID: tileID,
                 schema: ExternalWidgetRegistry.shared.metadata(for: identifier)?.settingsSchema ?? []
             )
-        case .calendarDate, .reminders, .batteries, .systemStatus, .search:
+        case .calendarDate, .reminders, .batteries, .systemStatus, .search, .photoFrame:
             EmptyView()
         }
     }


### PR DESCRIPTION
## Summary

`WidgetKind.photoFrame` was added but two `switch` statements over `WidgetKind` were never updated, making them non-exhaustive and breaking compilation. This adds `.photoFrame` to the no-settings case lists in `hasConfigurableSettings` (WidgetSettingsSchema.swift) and the settings panel `content` switch (WidgetSettingsView.swift). The photo frame is a slideshow widget with no anchored per-instance settings panel today, so grouping it with the other no-settings cases matches current behavior.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

<!-- None -->

## How was this tested?

- macOS version: 15 (Sequoia)
- Xcode version: current toolchain
- Steps to reproduce / verify: `xcodebuild -scheme Docky -configuration Debug build CODE_SIGNING_ALLOWED=NO` now reports `** BUILD SUCCEEDED **` with no error lines.

## Screenshots / recordings

<!-- No UI changes. -->

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [ ] I tested the change on macOS 14.0 or later.
- [ ] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [ ] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
