### PR TITLE
feat(settings): add autohide animation duration preference

### DIFF
--- a/Docky/Services/DockyPreferences.swift
+++ b/Docky/Services/DockyPreferences.swift
@@ -1773,6 +1773,27 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         }
     }
 
+    /// Duration of Docky's autohide slide (show/hide) window animation. A value
+    /// of 0 snaps the window into place instantly.
+    var autohideAnimationDuration: TimeInterval {
+        didSet {
+            let clampedValue = min(max(0, autohideAnimationDuration), 1)
+            guard clampedValue != oldValue else {
+                if autohideAnimationDuration != clampedValue {
+                    autohideAnimationDuration = clampedValue
+                }
+                return
+            }
+
+            if autohideAnimationDuration != clampedValue {
+                autohideAnimationDuration = clampedValue
+                return
+            }
+
+            defaults.set(clampedValue, forKey: Keys.autohideAnimationDuration)
+        }
+    }
+
     /// How Docky reacts to a maximized (visibleFrame-sized, non-fullscreen)
     /// window on its target screen.
     var maximizedWindowBehavior: MaximizedWindowBehavior {
@@ -3531,6 +3552,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         static let folderBadgePreviewStyle = "docky.folderBadgePreviewStyle"
         static let opensAtLogin = "docky.opensAtLogin"
         static let autohideWindowDelay = "docky.autohideWindowDelay"
+        static let autohideAnimationDuration = "docky.autohideAnimationDuration"
         static let fullscreenRevealDelay = "docky.fullscreenRevealDelay"
         static let windowPreviewHoverDelay = "docky.windowPreviewHoverDelay"
         static let windowPreviewLayout = "docky.windowPreviewLayout"
@@ -3639,6 +3661,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         static let folderBadgePreviewStyle: FolderBadgePreviewStyle = .dot
         static let opensAtLogin = true
         static let autohideWindowDelay: TimeInterval = 0.5
+        static let autohideAnimationDuration: TimeInterval = 0.22
         static let fullscreenRevealDelay: TimeInterval = 0.5
         static let windowPreviewHoverDelay: TimeInterval = 1.0
         static let windowPreviewLayout: WindowSwitcherLayout = .auto
@@ -3770,6 +3793,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         let storedFolderBadgePreviewStyle = defaults.string(forKey: Keys.folderBadgePreviewStyle)
         let storedOpensAtLogin = defaults.object(forKey: Keys.opensAtLogin) as? Bool
         let storedAutohideWindowDelay = defaults.object(forKey: Keys.autohideWindowDelay) as? Double
+        let storedAutohideAnimationDuration = defaults.object(forKey: Keys.autohideAnimationDuration) as? Double
         let storedFullscreenRevealDelay = defaults.object(forKey: Keys.fullscreenRevealDelay) as? Double
         let storedWindowPreviewHoverDelay = defaults.object(forKey: Keys.windowPreviewHoverDelay) as? Double
         let storedWindowPreviewLayout = defaults.string(forKey: Keys.windowPreviewLayout)
@@ -3899,6 +3923,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
             ?? DefaultValues.folderBadgePreviewStyle
         self.opensAtLogin = storedOpensAtLogin ?? LaunchAtLoginService.shared.isEnabled
         self.autohideWindowDelay = max(storedAutohideWindowDelay ?? DefaultValues.autohideWindowDelay, 0)
+        self.autohideAnimationDuration = min(max(storedAutohideAnimationDuration ?? DefaultValues.autohideAnimationDuration, 0), 1)
         self.fullscreenRevealDelay = max(storedFullscreenRevealDelay ?? DefaultValues.fullscreenRevealDelay, 0)
         self.windowPreviewHoverDelay = max(storedWindowPreviewHoverDelay ?? DefaultValues.windowPreviewHoverDelay, 0)
         self.windowPreviewLayout = storedWindowPreviewLayout.flatMap(WindowSwitcherLayout.init(rawValue:)) ?? DefaultValues.windowPreviewLayout
@@ -4166,6 +4191,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         folderBadgeMode = DefaultValues.folderBadgeMode
         folderBadgePreviewStyle = DefaultValues.folderBadgePreviewStyle
         autohideWindowDelay = DefaultValues.autohideWindowDelay
+        autohideAnimationDuration = DefaultValues.autohideAnimationDuration
         hidesDuringFullscreen = DefaultValues.hidesDuringFullscreen
         fullscreenRevealDelay = DefaultValues.fullscreenRevealDelay
         enablesShelveMode = DefaultValues.enablesShelveMode
@@ -4225,6 +4251,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         folderBadgePreviewStyle = DefaultValues.folderBadgePreviewStyle
         opensAtLogin = DefaultValues.opensAtLogin
         autohideWindowDelay = DefaultValues.autohideWindowDelay
+        autohideAnimationDuration = DefaultValues.autohideAnimationDuration
         fullscreenRevealDelay = DefaultValues.fullscreenRevealDelay
         windowPreviewHoverDelay = DefaultValues.windowPreviewHoverDelay
         windowPreviewLayout = DefaultValues.windowPreviewLayout

--- a/Docky/Views/MainWindow/MainWindow.swift
+++ b/Docky/Views/MainWindow/MainWindow.swift
@@ -183,7 +183,6 @@ final class MainWindow: NSPanel {
 
     private let backgroundBlurRadius = 10
     private let hiddenRevealThickness: CGFloat = 2
-    private let baseAutohideAnimationDuration: TimeInterval = 0.22
     private let tileMutationAnimationDuration: TimeInterval = 0.18
     private let dockSettings = DockSettingsService.shared
     private let preferences = DockyPreferences.shared
@@ -851,7 +850,7 @@ final class MainWindow: NSPanel {
     }
 
     private var autohideAnimationDuration: TimeInterval {
-        max(0.16, min(0.5, baseAutohideAnimationDuration * max(dockSettings.autohideTimeModifier, 0.01)))
+        min(max(0, preferences.autohideAnimationDuration), 1)
     }
 
     private func overflowContentScale(

--- a/Docky/Views/SettingsWindow/BehaviorSettingsView.swift
+++ b/Docky/Views/SettingsWindow/BehaviorSettingsView.swift
@@ -186,6 +186,28 @@ struct BehaviorSettingsView: View {
             .disabled(!preferences.autohidesWindow)
 
             VStack(alignment: .leading, spacing: 8) {
+                Text("Animation Duration")
+                    .font(.headline)
+
+                HStack {
+                    Slider(value: $preferences.autohideAnimationDuration, in: 0...1, step: 0.05) {
+                        Text("Animation Duration")
+                    }
+                    .labelsHidden()
+
+                    Text("\(String(format: "%.2f", preferences.autohideAnimationDuration)) s")
+                        .foregroundStyle(.secondary)
+                        .frame(width: 56, alignment: .trailing)
+                }
+
+                Text("How long the slide takes when Docky shows or hides its window. Set to 0 to snap instantly.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 4)
+            .disabled(!preferences.autohidesWindow)
+
+            VStack(alignment: .leading, spacing: 8) {
                 Toggle("Hide in Fullscreen", isOn: $preferences.hidesDuringFullscreen)
                     .font(.headline)
 


### PR DESCRIPTION
## Summary

Closes #37 

Adds a user preference for the duration of Docky's autohide show/hide slide animation. Previously the slide duration was only adjustable indirectly through the system Dock's `autohide-time-modifier`; this exposes a dedicated, authoritative control.

- New `DockyPreferences.autohideAnimationDuration` (default `0.22s`, clamped `0...1`), persisted to UserDefaults following the existing delay-preference pattern.
- `MainWindow` now reads the preference directly for its slide animation (replacing the `base * autohideTimeModifier` heuristic), so the setting is predictable.
- New "Animation Duration" slider in Settings > Behavior > Visibility (`0...1s`, step `0.05`), disabled when autohide is off. `0s` snaps the window instantly.

The existing "Autohide Delay" and "Fullscreen Reveal Delay" controls are unchanged.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

## How was this tested?

- macOS version: 15 (Sequoia)
- Xcode version: current
- Steps to reproduce / verify:
  1. Build and run the `Docky` scheme (`** BUILD SUCCEEDED **`).
  2. Open Settings > Behavior > Visibility, adjust the new Animation Duration slider.
  3. Trigger autohide (pointer leaves the dock) and confirm the slide honors the chosen duration; `0s` snaps instantly.

## Screenshots / recordings

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [ ] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [ ] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.