### PR TITLE
fix(dock): hide for full-axis tiled windows flush against Docky's edge

### DIFF
--- a/Docky/Views/MainWindow/MainWindow.swift
+++ b/Docky/Views/MainWindow/MainWindow.swift
@@ -1024,6 +1024,7 @@ final class MainWindow: NSPanel {
         let ownPID = ProcessInfo.processInfo.processIdentifier
         let frame = screen.frame
         let visibleFrame = screen.visibleFrame
+        let dockSide = preferences.windowPosition.resolved(systemOrientation: dockSettings.orientation)
         var fullscreenCandidate = false
         var foundMaximized = false
         var fullscreenCandidatePIDs = Set<pid_t>()
@@ -1050,12 +1051,16 @@ final class MainWindow: NSPanel {
             )
 
             // Fullscreen: window covers the entire NSScreen.frame (including
-            // the menubar area). Maximized: window matches visibleFrame
-            // exactly, which is smaller than frame by the menubar.
+            // the menubar area). Maximized: window fills a full axis of the
+            // visibleFrame flush against Docky's edge, so it falls behind
+            // Docky. This catches a true maximize (all four edges flush) as
+            // well as a half tile that spans the full axis touching Docky
+            // (e.g. tiled right with Docky on the right, or tiled top with
+            // Docky on either side), which a strict visibleFrame match misses.
             if Self.rect(nsBounds, matches: frame) {
                 fullscreenCandidate = true
                 if let ownerPID { fullscreenCandidatePIDs.insert(ownerPID) }
-            } else if Self.rect(nsBounds, matches: visibleFrame) {
+            } else if Self.fillsFullAxisBehindDock(nsBounds, visibleFrame: visibleFrame, dockSide: dockSide) {
                 foundMaximized = true
             }
         }
@@ -1100,5 +1105,32 @@ final class MainWindow: NSPanel {
             && abs(a.minY - b.minY) < tolerance
             && abs(a.width - b.width) < tolerance
             && abs(a.height - b.height) < tolerance
+    }
+
+    /// True when `rect` fills a full axis of `visibleFrame` (at least three
+    /// edges flush, i.e. a half tile or full maximize) AND is flush against
+    /// the edge Docky occupies, meaning it extends into Docky's strip. A
+    /// window with a non-flush edge on Docky's side (e.g. tiled to the
+    /// opposite half) stays clear and returns false.
+    private static func fillsFullAxisBehindDock(
+        _ rect: CGRect,
+        visibleFrame: CGRect,
+        dockSide: ResolvedDockWindowPosition,
+        tolerance: CGFloat = 2
+    ) -> Bool {
+        let flushLeft = abs(rect.minX - visibleFrame.minX) < tolerance
+        let flushRight = abs(rect.maxX - visibleFrame.maxX) < tolerance
+        let flushBottom = abs(rect.minY - visibleFrame.minY) < tolerance
+        let flushTop = abs(rect.maxY - visibleFrame.maxY) < tolerance
+
+        let flushCount = [flushLeft, flushRight, flushBottom, flushTop].filter { $0 }.count
+        guard flushCount >= 3 else { return false }
+
+        switch dockSide {
+        case .left: return flushLeft
+        case .right: return flushRight
+        case .bottom: return flushBottom
+        case .top: return flushTop
+        }
     }
 }


### PR DESCRIPTION
## Summary

Docky now hides for windows tiled to fill a full screen axis (not just fully maximized ones) when they sit flush against Docky's edge and would otherwise fall behind it. Previously the hide path only matched a window that filled the entire `visibleFrame`, so a window tiled to the right (full height) or tiled to the top (full width) slipped behind Docky without triggering the hide behavior.

Detection now flags a window when it has at least 3 edges flush against the `visibleFrame` (a half tile or full maximize) **and** the flush edge is the one Docky occupies, so a window tiled to the opposite half stays clear.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

<!-- none -->

## How was this tested?

- macOS version: 26.5.1
- Xcode version: 26.4
- Steps to reproduce / verify:
  - Set maximized-window behavior to **Hide Docky**.
  - Pin Docky to the right; tile a window to the right half (fills full height) → Docky hides.
  - Pin Docky to the left/right side; tile a window to the top (fills full width) → Docky hides.
  - Tile a window to the opposite half (or, with Docky on the bottom, tile to the top) → Docky stays visible.

## Screenshots / recordings

<!-- n/a -->

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [ ] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
