### PR TITLE
feat(taskbar): hide apps without open windows

### DIFF
--- a/Docky/Services/DockyPreferences.swift
+++ b/Docky/Services/DockyPreferences.swift
@@ -1962,6 +1962,14 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         }
     }
 
+    /// Whether Docky hides unpinned running apps that have no open windows.
+    var hidesAppsWithoutOpenWindows: Bool {
+        didSet {
+            guard hidesAppsWithoutOpenWindows != oldValue else { return }
+            defaults.set(hidesAppsWithoutOpenWindows, forKey: Keys.hidesAppsWithoutOpenWindows)
+        }
+    }
+
     /// Behavior when clicking an app tile whose app is already frontmost with at least one
     /// visible window. `.none` is the default; `.cycleWindows` and `.minimizeAll` are pro-only.
     var appTileFrontmostClickBehavior: AppTileFrontmostClickBehavior {
@@ -3565,6 +3573,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         static let widgetHoverPreviewDelay = "docky.widgetHoverGrowDelay"
         static let showsActivePinnedSeparator = "docky.showsActivePinnedSeparator"
         static let showsRunningApps = "docky.showsRunningApps"
+        static let hidesAppsWithoutOpenWindows = "docky.hidesAppsWithoutOpenWindows"
         static let showsMinimizedWindows = "docky.showsMinimizedWindows"
         static let hidesDuringFullscreen = "docky.hidesDuringFullscreen"
         static let enablesShelveMode = "docky.enablesShelveMode"
@@ -3674,6 +3683,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         static let widgetHoverPreviewDelay: TimeInterval = 1
         static let showsActivePinnedSeparator = true
         static let showsRunningApps = true
+        static let hidesAppsWithoutOpenWindows = false
         static let showsMinimizedWindows = true
         static let hidesDuringFullscreen = true
         static let enablesShelveMode = false
@@ -3806,6 +3816,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         let storedWidgetHoverPreviewDelay = defaults.object(forKey: Keys.widgetHoverPreviewDelay) as? Double
         let storedShowsActivePinnedSeparator = defaults.object(forKey: Keys.showsActivePinnedSeparator) as? Bool
         let storedShowsRunningApps = defaults.object(forKey: Keys.showsRunningApps) as? Bool
+        let storedHidesAppsWithoutOpenWindows = defaults.object(forKey: Keys.hidesAppsWithoutOpenWindows) as? Bool
         let storedShowsMinimizedWindows = defaults.object(forKey: Keys.showsMinimizedWindows) as? Bool
         let storedEnablesShelveMode = defaults.object(forKey: Keys.enablesShelveMode) as? Bool
         let storedShelveHidesFinder = defaults.object(forKey: Keys.shelveHidesFinder) as? Bool
@@ -3938,6 +3949,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         self.widgetHoverPreviewDelay = max(storedWidgetHoverPreviewDelay ?? DefaultValues.widgetHoverPreviewDelay, 0)
         self.showsActivePinnedSeparator = storedShowsActivePinnedSeparator ?? DefaultValues.showsActivePinnedSeparator
         self.showsRunningApps = storedShowsRunningApps ?? DefaultValues.showsRunningApps
+        self.hidesAppsWithoutOpenWindows = storedHidesAppsWithoutOpenWindows ?? DefaultValues.hidesAppsWithoutOpenWindows
         self.showsMinimizedWindows = storedShowsMinimizedWindows ?? DefaultValues.showsMinimizedWindows
         self.hidesDuringFullscreen = (defaults.object(forKey: Keys.hidesDuringFullscreen) as? Bool) ?? DefaultValues.hidesDuringFullscreen
         self.enablesShelveMode = storedEnablesShelveMode ?? DefaultValues.enablesShelveMode
@@ -4199,6 +4211,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         shelveHidesTrash = DefaultValues.shelveHidesTrash
         hidesRecentApps = DefaultValues.hidesRecentApps
         showsRunningApps = DefaultValues.showsRunningApps
+        hidesAppsWithoutOpenWindows = DefaultValues.hidesAppsWithoutOpenWindows
         showsMinimizedWindows = DefaultValues.showsMinimizedWindows
         showsActivePinnedSeparator = DefaultValues.showsActivePinnedSeparator
 
@@ -4264,6 +4277,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         widgetHoverPreviewDelay = DefaultValues.widgetHoverPreviewDelay
         showsActivePinnedSeparator = DefaultValues.showsActivePinnedSeparator
         showsRunningApps = DefaultValues.showsRunningApps
+        hidesAppsWithoutOpenWindows = DefaultValues.hidesAppsWithoutOpenWindows
         showsMinimizedWindows = DefaultValues.showsMinimizedWindows
         hidesDuringFullscreen = DefaultValues.hidesDuringFullscreen
         enablesShelveMode = DefaultValues.enablesShelveMode

--- a/Docky/Services/TileStore.swift
+++ b/Docky/Services/TileStore.swift
@@ -80,6 +80,10 @@ final class TileStore: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.rebuildTiles() }
             .store(in: &cancellables)
+        WindowRegistry.shared.$windows
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.rebuildTiles() }
+            .store(in: &cancellables)
         // `DockyPreferences` is `@Observable`. We observe each
         // property bundle through `observeChanges` so the same change
         // signal fires only when the relevant property mutates.
@@ -119,6 +123,7 @@ final class TileStore: ObservableObject {
             _ = DockyPreferences.shared.showsGroupedOpenedAppsInDock
             _ = DockyPreferences.shared.effectiveShowsActivePinnedSeparator
             _ = DockyPreferences.shared.showsRunningApps
+            _ = DockyPreferences.shared.hidesAppsWithoutOpenWindows
             _ = DockyPreferences.shared.showsMinimizedWindows
             _ = DockyPreferences.shared.enablesShelveMode
             _ = DockyPreferences.shared.shelveHidesFinder
@@ -2199,10 +2204,25 @@ final class TileStore: ObservableObject {
                     && !pinnedBundleIDs.contains($0.bundleIdentifier)
                     && !hiddenBundleIDs.contains($0.bundleIdentifier)
             }
+        let appsWithoutOpenWindows: Set<String>
+        if preferences.hidesAppsWithoutOpenWindows,
+           PermissionsService.shared.accessibility == .granted {
+            let bundleIDsWithOpenWindows = Set(WindowRegistry.shared.windows.map(\.bundleIdentifier))
+            appsWithoutOpenWindows = Set(currentUnpinned.map(\.bundleIdentifier))
+                .subtracting(bundleIDsWithOpenWindows)
+        } else {
+            // Without Accessibility, the registry is incomplete. Keep the
+            // normal running-app list rather than incorrectly hiding every app.
+            appsWithoutOpenWindows = []
+        }
+        let openWindowUnpinned = currentUnpinned.filter {
+            !appsWithoutOpenWindows.contains($0.bundleIdentifier)
+        }
 
         displayedRunning = resolveDisplayedRunning(
-            currentUnpinned: currentUnpinned,
-            pinnedBundleIDs: pinnedBundleIDs
+            currentUnpinned: openWindowUnpinned,
+            pinnedBundleIDs: pinnedBundleIDs,
+            excludedBundleIDs: appsWithoutOpenWindows
         )
 
         let shelveMode = preferences.enablesShelveMode
@@ -2498,9 +2518,12 @@ final class TileStore: ObservableObject {
     ///   - A non-rightmost exit drops the tile (shifts remaining left).
     ///   - A rightmost exit holds the slot as a ghost until something newer
     ///     launches to take its place (or the ghost's bundle gets pinned).
+    ///   - Apps excluded by the open-window preference are removed rather
+    ///     than preserved as ghosts.
     private func resolveDisplayedRunning(
         currentUnpinned: [RunningApp],
-        pinnedBundleIDs: Set<String>
+        pinnedBundleIDs: Set<String>,
+        excludedBundleIDs: Set<String>
     ) -> [RunningApp] {
         let hiddenBundleIDs = Set(preferences.hiddenAppBundleIdentifiers)
         let currentMap = Dictionary(
@@ -2514,7 +2537,8 @@ final class TileStore: ObservableObject {
 
         for (index, existing) in displayedRunning.enumerated() {
             if pinnedBundleIDs.contains(existing.bundleIdentifier)
-                || hiddenBundleIDs.contains(existing.bundleIdentifier) {
+                || hiddenBundleIDs.contains(existing.bundleIdentifier)
+                || excludedBundleIDs.contains(existing.bundleIdentifier) {
                 continue
             }
             if let live = currentMap[existing.bundleIdentifier] {
@@ -2527,12 +2551,14 @@ final class TileStore: ObservableObject {
         let existingIDs = Set(displayedRunning.map(\.bundleIdentifier))
         for app in currentUnpinned
         where !existingIDs.contains(app.bundleIdentifier)
-            && !hiddenBundleIDs.contains(app.bundleIdentifier) {
+            && !hiddenBundleIDs.contains(app.bundleIdentifier)
+            && !excludedBundleIDs.contains(app.bundleIdentifier) {
             survived.append(app)
         }
 
         if let ghost = pendingGhost,
-           !hiddenBundleIDs.contains(ghost.bundleIdentifier) {
+           !hiddenBundleIDs.contains(ghost.bundleIdentifier),
+           !excludedBundleIDs.contains(ghost.bundleIdentifier) {
             let ghostLaunch = ghost.launchDate ?? .distantPast
             let hasNewer = survived.contains { app in
                 (app.launchDate ?? .distantPast) > ghostLaunch

--- a/Docky/Views/SettingsWindow/BehaviorSettingsView.swift
+++ b/Docky/Views/SettingsWindow/BehaviorSettingsView.swift
@@ -20,6 +20,7 @@ struct BehaviorSettingsView: View {
     let subsection: Subsection
 
     @Bindable private var preferences = DockyPreferences.shared
+    @ObservedObject private var permissions = PermissionsService.shared
     @State private var isShowingResetConfirmation = false
 
     var body: some View {
@@ -325,6 +326,17 @@ struct BehaviorSettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             .padding(.vertical, 4)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Toggle("Hide Apps Without Open Windows", isOn: $preferences.hidesAppsWithoutOpenWindows)
+                    .font(.headline)
+
+                Text("Hides unpinned running apps that have no open windows. Minimized windows keep their app visible. Requires Accessibility permission.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 4)
+            .disabled(!preferences.showsRunningApps || permissions.accessibility != .granted)
 
             VStack(alignment: .leading, spacing: 8) {
                 Toggle("Show Notification Badges", isOn: $preferences.showsAppBadges)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Optionally show running apps inline so a folder doubles as a live workspace.
 
 - **Custom app icons:** override the icon for any pinned, running, or
   widget-backed app.
+- **Focused taskbar:** optionally hide unpinned apps that are running without
+  any open windows, while keeping apps with minimized windows visible.
 - **Scripted actions:** catalog-backed AppleScript and menu-click automation,
   plus curated commands.
 - **Themes and profiles:** themeable appearance and switchable configuration


### PR DESCRIPTION
## Summary

Adds an opt-in setting to hide unpinned apps that are running without any open windows. This removes background-only apps, such as Calendar after its windows are closed, from Docky’s taskbar while keeping apps with minimized windows and pinned apps visible.

## Type of change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that changes existing behavior)
* [ ] Refactor / performance (no functional change)
* [ ] Documentation
* [ ] Build / tooling / CI

## Related issues

None.

## How was this tested?

* macOS version: 26.6.1 (25G76)
* Xcode version: 26.6
* Steps to reproduce / verify:

  1. Grant Docky Accessibility permission.
  2. Enable **Behavior → Visibility → Hide Apps Without Open Windows**.
  3. Launch an unpinned app, then close all of its windows. Confirm its taskbar tile disappears while it remains running.
  4. Minimize an app window. Confirm its taskbar tile remains visible.
  5. Confirm pinned app tiles remain visible.

## Screenshots / recordings

Not included.

## Checklist

* [x] The `Docky` scheme builds without new warnings.
* [x] I tested the change on macOS 14.0 or later.
* [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
* [x] Commit messages follow the `type(scope): summary` convention used in this repo.
* [x] I updated documentation (README, comments) where needed.
* [x] My changes are licensed under GPLv3, consistent with the rest of the project.
