### PR TITLE
fix(dock): activate apps by transferring activation so tile clicks work with Settings open

### DIFF
--- a/Docky/Services/AppActivation.swift
+++ b/Docky/Services/AppActivation.swift
@@ -1,0 +1,35 @@
+//
+//  AppActivation.swift
+//  Docky
+//
+//  Shared entry point for every "bring this other app forward" call.
+//
+//  Since macOS 14 activation is cooperative: `NSRunningApplication.activate`
+//  is honored only when the *requesting* process is allowed to hand over
+//  activation. A `.regular` app that isn't itself frontmost is not, so the
+//  call returns false and nothing happens. Docky normally runs `.accessory`,
+//  which the system exempts — but it promotes to `.regular` while the
+//  Settings or Permissions window is open, and for as long as that window
+//  stayed open every dock-tile click silently failed to switch apps (#35).
+//
+//  `activate(from:)` sidesteps the whole question by transferring activation
+//  from whichever app currently owns it, and is honored under either policy.
+//
+
+import AppKit
+
+extension NSRunningApplication {
+    /// Activates the app by transferring activation away from the frontmost
+    /// app, so it works whether or not Docky is `.accessory` or frontmost.
+    @discardableResult
+    func activateTransferringFrontmost(options: NSApplication.ActivationOptions = []) -> Bool {
+        let donor = NSWorkspace.shared.frontmostApplication ?? .current
+        if activate(from: donor, options: options) {
+            return true
+        }
+
+        // Donor may have quit or lost the front slot between the lookup and
+        // the call; a plain activate still succeeds while Docky is `.accessory`.
+        return activate(options: options)
+    }
+}

--- a/Docky/Services/WindowRegistry.swift
+++ b/Docky/Services/WindowRegistry.swift
@@ -290,7 +290,7 @@ final class WindowRegistry: ObservableObject {
         if let runningApp = NSRunningApplication(processIdentifier: window.processIdentifier) {
             DispatchQueue.main.async {
                 runningApp.unhide()
-                _ = runningApp.activate()
+                runningApp.activateTransferringFrontmost()
             }
         }
 

--- a/Docky/Services/WorkspaceService.swift
+++ b/Docky/Services/WorkspaceService.swift
@@ -152,7 +152,7 @@ final class WorkspaceService: ObservableObject {
 
         // Default: bring the app forward.
         runningApp.unhide()
-        runningApp.activate(options: [.activateAllWindows])
+        runningApp.activateTransferringFrontmost(options: [.activateAllWindows])
     }
 
     private func applyFrontmostAppTileClickBehavior(
@@ -318,7 +318,7 @@ final class WorkspaceService: ObservableObject {
         }
 
         runningApp.unhide()
-        _ = runningApp.activate()
+        runningApp.activateTransferringFrontmost()
     }
 
     @discardableResult
@@ -541,7 +541,7 @@ final class WorkspaceService: ObservableObject {
         }
 
         runningApp.unhide()
-        _ = runningApp.activate()
+        runningApp.activateTransferringFrontmost()
         // The Dock targets App Exposé at whatever app is frontmost when the
         // call arrives. The small delay lets activation land first so Exposé
         // surfaces the correct app's windows.


### PR DESCRIPTION
## Summary

While the Settings (or Permissions) window is open, clicking a running app's tile in the dock did nothing — the app never came forward, so the previously focused app stayed on top of everything.

Root cause: since macOS 14 activation is cooperative. `NSRunningApplication.activate(options:)` is honored only when the requesting process is allowed to hand over activation — a `.regular` app that isn't itself frontmost is not, and the call just returns `false`. Docky normally runs `.accessory`, which the system exempts, but `showSettingsWindow` promotes it to `.regular` and only demotes it when the window closes. For as long as Settings stayed open, every tile click was silently denied.

That also explains why the workarounds in the report still worked: launching an app goes through LaunchServices (which activates on Docky's behalf), and window previews go through the private SLPS path in `WindowRegistry.focusViaSLPS`, neither of which is subject to the policy check.

Fix: a shared `NSRunningApplication.activateTransferringFrontmost(options:)` helper that uses `activate(from:)` to transfer activation away from whichever app currently owns it. The system honors that under either activation policy, active or not. Public API, available on the project's macOS 14 deployment target. It falls back to a plain `activate` if the donor app disappears between the lookup and the call.

Routed the four "bring another app forward" call sites through it — every dock/switcher/Exposé path funnels into these:

- `WorkspaceService.activateOrOpen` — the dock tile click from the issue
- `WorkspaceService.focusApplication` — window switcher / preview click
- `WorkspaceService.showAllWindows` — App Exposé action
- `WindowRegistry.focus` — the non-SLPS fallback

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [ ] Documentation
- [ ] Build / tooling / CI

## Related issues

Closes #35

## How was this tested?

- macOS version: 26.6.1
- Xcode version: 26.6
- Steps to reproduce / verify:
  1. Open the Docky settings window.
  2. Focus another app.
  3. Click a running app's tile in the dock — the app now comes forward and takes focus, with the settings window still open.
  4. Close settings and confirm normal tile clicks are unchanged.

Verified in a Debug build of the app. The underlying activation behavior was also isolated in a standalone harness (a `.regular`, inactive app with a visible window, targeting Finder while another app was frontmost):

| Policy | Call | Result |
| --- | --- | --- |
| `.accessory`, inactive | `activate(options:)` | `true` — target activates |
| `.regular`, inactive | `activate(options:)` | **`false` — nothing happens** |
| `.regular`, inactive | `yieldActivation` + `activate` | `false` (yield requires being active) |
| `.regular`, inactive | `activate(from:options:)` | `true` — target activates |
| `.accessory`, inactive | `activate(from:options:)` | `true` — no regression on the normal path |

## Screenshots / recordings

No UI changes.

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
