### PR TITLE
fix(dock): conceal the hidden dock's reveal sliver instead of leaving it painted

### DIFF
--- a/Docky/Views/MainWindow/MainWindow.swift
+++ b/Docky/Views/MainWindow/MainWindow.swift
@@ -182,6 +182,11 @@ final class MainWindow: NSPanel {
     }
 
     private let backgroundBlurRadius = 10
+    /// The hidden panel stays this many points on screen. The reveal is
+    /// driven by the content view's tracking area (`mouseEntered`), so the
+    /// window has to keep a sliver of itself hittable at the screen edge —
+    /// but nothing about that sliver should ever be *seen*, which is what
+    /// `applyVisibilityAppearance()` takes care of.
     private let hiddenRevealThickness: CGFloat = 2
     private let tileMutationAnimationDuration: TimeInterval = 0.18
     private let dockSettings = DockSettingsService.shared
@@ -325,13 +330,32 @@ final class MainWindow: NSPanel {
         applyBackgroundBlur()
     }
 
+    /// The blur is a WindowServer-side backdrop filter over the panel's
+    /// whole frame, independent of anything the content view draws. While
+    /// hidden that meant the leftover reveal sliver kept smearing whatever
+    /// sat behind it along the screen edge — most visibly over a fullscreen
+    /// app, where a blurred band of the desktop showed through. Radius 0
+    /// detaches the filter, so the blur only exists while the dock does.
     private func applyBackgroundBlur() {
         guard windowNumber > 0 else { return }
         _ = CGSSetWindowBackgroundBlurRadius(
             CGSMainConnectionID(),
             windowNumber,
-            backgroundBlurRadius
+            visibilityState == .hidden ? 0 : backgroundBlurRadius
         )
+    }
+
+    /// Keeps the panel's on-screen appearance in sync with the visibility
+    /// state. Hidden means fully transparent with no backdrop blur: the
+    /// reveal sliver stays where it is and keeps receiving mouse-entered
+    /// events (a zero-alpha window is still hit-tested), it just stops
+    /// painting. Without this the sliver leaked the blurred backdrop, and
+    /// in full-axis mode — where the chrome fills the panel instead of
+    /// leaving magnification headroom at the inward edge — it also left a
+    /// visible strip of live dock chrome at the screen edge.
+    private func applyVisibilityAppearance() {
+        alphaValue = visibilityState == .hidden ? 0 : 1
+        applyBackgroundBlur()
     }
 
     private func observeFrameInputs() {
@@ -830,23 +854,44 @@ final class MainWindow: NSPanel {
     private func applyFrame(_ frame: CGRect, animated: Bool, duration: TimeInterval?) {
         let shouldAnimate = animated && hasResolvedInitialFrame
 
+        // Revealing paints up front so the dock is visible for the whole
+        // slide in; hiding waits for the completion handler below, so it
+        // slides out instead of blinking away.
+        if hasResolvedInitialFrame, visibilityState == .visible {
+            applyVisibilityAppearance()
+        }
+
         guard shouldAnimate else {
             setFrame(frame, display: true, animate: false)
-            revealAfterInitialFrameIfNeeded()
+            markInitialFrameResolvedIfNeeded()
+            applyVisibilityAppearance()
             return
         }
 
-        NSAnimationContext.runAnimationGroup { context in
+        NSAnimationContext.runAnimationGroup({ context in
             context.duration = duration ?? autohideAnimationDuration
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             animator().setFrame(frame, display: true)
-        }
+        }, completionHandler: { [weak self] in
+            // Animation completions land on the main thread; the closure
+            // itself is nonisolated, so state has to be touched through
+            // `assumeIsolated` (same bridge `DockBadgeService` uses).
+            MainActor.assumeIsolated {
+                // A reveal that interrupts this hide flips the state back
+                // to `.visible` and repaints itself, so bail rather than
+                // blanking a dock that's on its way in.
+                guard let self, self.visibilityState == .hidden else { return }
+                self.applyVisibilityAppearance()
+            }
+        })
     }
 
-    private func revealAfterInitialFrameIfNeeded() {
+    /// The panel is created at `alphaValue = 0` so it never flashes at a
+    /// half-computed frame. Once the first real frame lands, appearance is
+    /// driven by the visibility state instead.
+    private func markInitialFrameResolvedIfNeeded() {
         guard !hasResolvedInitialFrame else { return }
         hasResolvedInitialFrame = true
-        alphaValue = 1
     }
 
     private var autohideAnimationDuration: TimeInterval {


### PR DESCRIPTION
## Summary

When the dock hides (autohide, hide-in-fullscreen, or hide-when-maximized) it doesn't move fully off screen — `frameOrigin` deliberately leaves `hiddenRevealThickness` (2pt) of the panel at the screen edge, because the reveal is driven by the content view's `NSTrackingArea` and the window needs to stay hittable. That sliver was left fully painted, which is both halves of this report:

- **Part 1** — the panel carries a WindowServer-side backdrop blur (`CGSSetWindowBackgroundBlurRadius`, radius 10) applied to its *whole frame*, independent of anything the content view draws. The hidden 2pt strip kept smearing whatever sat behind it along the screen edge; over a fullscreen app that reads as a blurred band of desktop. It's a compositor-side filter, which is also why the reporter couldn't capture it in a screenshot.
- **Part 2** — in full-axis mode the chrome fills the panel instead of leaving magnification headroom at the inward edge, so those same 2pt are live dock chrome. Fit-content mode leaves headroom there, which is why the report only sees this on "Full Axis".

Fix: `applyVisibilityAppearance()` keeps the panel's appearance tied to the visibility state — hidden means `alphaValue = 0` and blur radius 0. The sliver stays exactly where it is and keeps its tracking area, it just stops painting; a zero-alpha window is still hit-tested, so the reveal is unaffected. Concealment is applied on the *completion* of the hide animation so the dock still slides out rather than blinking away, and a reveal that interrupts a hide repaints up front and makes the stale completion handler bail.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [ ] Documentation
- [ ] Build / tooling / CI

## Related issues

Closes #14

## How was this tested?

- macOS version: 26.6.1
- Xcode version: 26.6
- Steps to reproduce / verify:
  1. Enable "Autohide Window" (or "Hide in Fullscreen" and fullscreen a window).
  2. With the dock hidden, look at the screen edge — no blurred band, no chrome sliver.
  3. Move the pointer to the edge: the dock still reveals.
  4. Move away, let it re-hide, then reveal again — repeat reveals still work.

Measured on the running Debug build by reading the panel's composited alpha out of `CGWindowListCopyWindowInfo` (`kCGWindowAlpha`), on a 1800×1169 screen with a bottom, full-axis dock:

| Dock state | Panel bounds | Alpha before | Alpha after |
| --- | --- | --- | --- |
| Hidden (2pt on screen) | (0, 1167) 1800×110 | **1.0 — painted** | **0.0** |
| Revealed | (0, 1059) 1800×110 | 1.0 | 1.0 |
| Re-hidden after reveal | (0, 1167) 1800×110 | 1.0 | 0.0 |
| Revealed a second time | (0, 1059) 1800×110 | — | 1.0 |

The last row is the regression that mattered: the hit target has to survive being invisible. That was also checked in isolation first — a standalone panel with the same tracking-area setup still fires `mouseEntered` at `alphaValue = 0`.

Not verified here: the on-screen appearance in fullscreen, since this environment can't take screenshots. The fullscreen path (`hidesDuringFullscreen`) reaches the same `.hidden` visibility state that the measurements above cover, but a visual confirmation of Part 1 is still worth a human pass.

## Screenshots / recordings

No intentional UI changes — the hidden dock renders nothing where it previously rendered a 2pt blurred/chrome strip.

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
