### PR TITLE
fix(permissions): make screen recording optional at launch

### DIFF
--- a/Docky/Services/PermissionsService.swift
+++ b/Docky/Services/PermissionsService.swift
@@ -111,7 +111,7 @@ enum Permission: String, CaseIterable, Identifiable {
         case .accessibility:
             return true
         case .screenCapture:
-            return true
+            return false
         case .location:
             return false
         case .calendar:


### PR DESCRIPTION
## Summary

Screen Recording was marked `isRequiredAtLaunch`, so `setupPermissions` re-surfaced it on every launch and the dock stayed hidden behind the onboarding window until it was granted. Skipping is only recorded when you press Skip during onboarding, so anyone who granted it and later revoked it had no way past that screen.

It is now optional. The step still appears during first run and can be granted later from Settings, and thumbnail previews already fall back to list layout when it is missing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [ ] Documentation
- [ ] Build / tooling / CI

## Related issues

Closes #54

## How was this tested?

- macOS version: 26.6.1
- Xcode version: 26.6
- Steps to reproduce / verify: with onboarding completed and Screen Recording not granted, launch Docky. Before the change it opened onboarding on the Screen Recording step with no dock. After it launches straight to the dock.

## Screenshots / recordings

No UI changes.

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
