### PR TITLE
perf(dock): cut idle CPU and whole-dock re-renders

### DIFF
--- a/Docky/Services/MediaPlaybackService.swift
+++ b/Docky/Services/MediaPlaybackService.swift
@@ -387,6 +387,7 @@ final class MediaPlaybackService: ObservableObject {
         """
 
         _ = try? AppleScriptService.shared.executeDescriptor(source: source)
+        mediaRemote.invalidateFavoriteCache()
         try? await Task.sleep(for: .milliseconds(120))
         refresh()
     }
@@ -478,6 +479,16 @@ private final class MediaRemoteBridge {
     private let helper = MediaRemoteHelperProcess()
     private var lastPayloadByBundleIdentifier: [String: MediaRemoteSnapshot.Payload] = [:]
     private var lastActiveBundleIdentifier: String?
+    // App display names never change at runtime; memoize the LaunchServices
+    // lookup so it doesn't run on every snapshot. Touched only from the
+    // helper drain thread (via `handle`).
+    private var displayNameCache: [String: String] = [:]
+    // Favorite state only changes when the track changes (or the user
+    // toggles it), so cache it per track key instead of firing an AppleScript
+    // round-trip to Music on every snapshot. Guarded because it's read from
+    // the drain thread but invalidated from the main thread on toggle.
+    private var favoriteByTrackKey: [String: Bool] = [:]
+    private let favoriteCacheLock = NSLock()
 
     private init() {
         let bundleURL = NSURL(fileURLWithPath: "/System/Library/PrivateFrameworks/MediaRemote.framework")
@@ -540,18 +551,51 @@ private final class MediaRemoteBridge {
             isPlaying: isPlaying,
             isAvailable: true,
             supportsFavorite: bundleIdentifier == "com.apple.Music",
-            isFavorite: fetchFavorite(bundleIdentifier: bundleIdentifier),
+            isFavorite: resolveFavorite(bundleIdentifier: bundleIdentifier, title: title, artist: artist, album: album),
             artworkData: artworkData,
             lastUpdated: Date()
         )
         onStateChange?(state)
     }
 
-    private func fetchFavorite(bundleIdentifier: String) -> Bool {
+    /// Clears the cached favorite state. Called from the main thread after
+    /// the user toggles favorite so the next snapshot for the same track
+    /// re-queries Music instead of returning the stale value.
+    func invalidateFavoriteCache() {
+        favoriteCacheLock.lock()
+        favoriteByTrackKey.removeAll()
+        favoriteCacheLock.unlock()
+    }
+
+    private func resolveFavorite(bundleIdentifier: String, title: String, artist: String, album: String) -> Bool {
         guard bundleIdentifier == "com.apple.Music" else {
             return false
         }
 
+        let trackKey = "\(bundleIdentifier)|\(title)|\(artist)|\(album)"
+
+        favoriteCacheLock.lock()
+        if let cached = favoriteByTrackKey[trackKey] {
+            favoriteCacheLock.unlock()
+            return cached
+        }
+        favoriteCacheLock.unlock()
+
+        let value = fetchFavorite()
+
+        favoriteCacheLock.lock()
+        // Bound the cache; playlists are long but we only need the current
+        // track's value to stay warm across repeated snapshots.
+        if favoriteByTrackKey.count > 64 {
+            favoriteByTrackKey.removeAll()
+        }
+        favoriteByTrackKey[trackKey] = value
+        favoriteCacheLock.unlock()
+
+        return value
+    }
+
+    private func fetchFavorite() -> Bool {
         let source = """
         tell application "Music"
             if it is running then
@@ -565,15 +609,29 @@ private final class MediaRemoteBridge {
         end tell
         """
 
-        return (try? AppleScriptService.shared.executeDescriptor(source: source))?.booleanValue ?? false
+        // NSAppleScript is documented as main-thread-only; `handle` runs on
+        // the helper's background drain thread, so hop to main for the
+        // Apple Event round-trip.
+        let run: () -> Bool = {
+            (try? AppleScriptService.shared.executeDescriptor(source: source))?.booleanValue ?? false
+        }
+        return Thread.isMainThread ? run() : DispatchQueue.main.sync(execute: run)
     }
 
     private func displayName(for bundleIdentifier: String) -> String {
-        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
-            return FileManager.default.displayName(atPath: url.path)
+        if let cached = displayNameCache[bundleIdentifier] {
+            return cached
         }
 
-        return bundleIdentifier
+        let resolved: String
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
+            resolved = FileManager.default.displayName(atPath: url.path)
+        } else {
+            resolved = bundleIdentifier
+        }
+
+        displayNameCache[bundleIdentifier] = resolved
+        return resolved
     }
 
     private static func function<T>(named name: String, in bundle: CFBundle?) -> T? {

--- a/Docky/Views/MainWindow/MainWindow.swift
+++ b/Docky/Views/MainWindow/MainWindow.swift
@@ -526,8 +526,17 @@ final class MainWindow: NSPanel {
     }
 
     /// A hidden panel sits off-screen, where its tracking area can't fire, so
-    /// the reveal runs off monitored pointer movement instead.
+    /// the reveal runs off monitored pointer movement instead. When autohide
+    /// is inactive the panel is always visible and `syncPointerPresence`
+    /// early-returns, so a global `.mouseMoved` monitor would wake Docky on
+    /// every system-wide pointer move for nothing — only keep it installed
+    /// while autohide can actually hide us. Re-synced from
+    /// `applyEffectiveVisibility` whenever that condition changes.
     private func updateRevealMonitoring() {
+        let shouldMonitor = effectivelyAutohides
+        let isMonitoring = globalDragRevealMonitor != nil || localDragRevealMonitor != nil
+        guard shouldMonitor != isMonitoring else { return }
+
         if let globalDragRevealMonitor {
             NSEvent.removeMonitor(globalDragRevealMonitor)
             self.globalDragRevealMonitor = nil
@@ -536,6 +545,8 @@ final class MainWindow: NSPanel {
             NSEvent.removeMonitor(localDragRevealMonitor)
             self.localDragRevealMonitor = nil
         }
+
+        guard shouldMonitor else { return }
 
         let revealEvents: NSEvent.EventTypeMask = [
             .mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged,
@@ -627,6 +638,9 @@ final class MainWindow: NSPanel {
 
     private func applyEffectiveVisibility(animated: Bool) {
         hideWorkItem?.cancel()
+        // `effectivelyAutohides` may have just flipped (autohide pref,
+        // fullscreen, or maximized state) — keep the reveal monitor in sync.
+        updateRevealMonitoring()
 
         if effectivelyAutohides {
             let nextState: VisibilityState = shouldRemainVisible ? .visible : .hidden

--- a/Docky/Views/Tiles/TileView.swift
+++ b/Docky/Views/Tiles/TileView.swift
@@ -29,7 +29,11 @@ struct TileView: View {
     @ObservedObject private var layout = DockLayoutService.shared
     @Bindable private var preferences = DockyPreferences.shared
     @ObservedObject private var workspace = WorkspaceService.shared
-    @ObservedObject private var mediaPlayback = MediaPlaybackService.shared
+    // Not an @ObservedObject: media state is read only inside context-menu
+    // and tap closures (never during `body`). Observing it here would
+    // re-render every tile on each MediaRemote snapshot — which arrives
+    // continuously while audio plays. Reach the shared instance directly.
+    private var mediaPlayback: MediaPlaybackService { .shared }
     @ObservedObject private var editMode = DockEditModeService.shared
     @ObservedObject private var widgetExpansion = WidgetExpansionWindowController.shared
     @ObservedObject private var dockDrag = DockDragService.shared
@@ -70,7 +74,6 @@ struct TileView: View {
         self._layout = ObservedObject(wrappedValue: DockLayoutService.shared)
         self._preferences = Bindable(wrappedValue: DockyPreferences.shared)
         self._workspace = ObservedObject(wrappedValue: WorkspaceService.shared)
-        self._mediaPlayback = ObservedObject(wrappedValue: MediaPlaybackService.shared)
         self._editMode = ObservedObject(wrappedValue: DockEditModeService.shared)
         self._widgetExpansion = ObservedObject(wrappedValue: WidgetExpansionWindowController.shared)
         self._dockDrag = ObservedObject(wrappedValue: DockDragService.shared)


### PR DESCRIPTION
## Summary

Three hot-path performance fixes for the always-on dock, found during a performance audit. Each is scoped and independently reviewable.

### 1. `TileView` no longer observes `MediaPlaybackService` (whole-dock re-render)
Every `TileView` held `@ObservedObject var mediaPlayback`, so any publish from `MediaPlaybackService` re-ran `body` on **every** tile. That service publishes on each MediaRemote snapshot — continuously while audio plays (track/elapsed/play-state changes, and the state struct carries `artworkData`). But media state is only ever read inside context-menu builders and tap handlers, never during `body`. Replaced the observed property with a plain accessor (`MediaPlaybackService.shared`); call sites are unchanged.

### 2. `MediaRemoteBridge` caches favorite + display name, runs AppleScript on main
`handle(_:)` runs on the helper's background drain thread and, on **every snapshot**, fired a synchronous `NSAppleScript` round-trip to Music (`fetchFavorite`) plus a LaunchServices lookup (`displayName`). `NSAppleScript` is documented main-thread-only. Now:
- display names are memoized (they don't change at runtime),
- favorite state is cached per track key and only re-queried on track change,
- the favorite AppleScript hops to the main thread,
- the cache is invalidated when the user toggles favorite.

### 3. Reveal `.mouseMoved` monitor installed only while autohide is active (idle CPU)
`updateRevealMonitoring()` installed a global `.mouseMoved` monitor unconditionally, waking Docky on every system-wide pointer move. When autohide is off, `syncPointerPresence()` early-returns — so the monitor did nothing but burn wakeups. It's now installed only while `effectivelyAutohides` is true and re-synced from `applyEffectiveVisibility` whenever that condition changes (autohide pref, fullscreen, maximized).

## Testing
- `xcodebuild -scheme Docky -configuration Debug build` — **BUILD SUCCEEDED**.
- No behavior change intended: media context actions/taps read fresh state on demand; favorite toggle invalidates its cache; reveal-on-hover still works while autohiding (monitor re-synced on state change).

## Notes
Scoped to the three highest-impact items (H1/H2/H3) from the audit. Further items (WorkspaceService thumbnail-publish decoupling, `SystemStatusService`/`DockBadgeService` gating, `IconCacheService` `totalCostLimit`) are left as follow-ups.