### PR TITLE
fix(dock): activate apps with windows on another Space instead of sending a no-op reopen

### DIFF
--- a/Docky/Private/CGSPrivate.swift
+++ b/Docky/Private/CGSPrivate.swift
@@ -121,9 +121,16 @@ private typealias SLPSPostEventRecordToType = @convention(c) (
     UnsafeMutablePointer<UInt8>
 ) -> CGError
 
+private typealias SLSWindowIsOrderedInType = @convention(c) (
+    CGSConnectionID,
+    CGWindowID,
+    UnsafeMutablePointer<Bool>
+) -> CGError
+
 private var skyLightHandle: UnsafeMutableRawPointer?
 private var setFrontProcessPtr: SLPSSetFrontProcessWithOptionsType?
 private var postEventRecordPtr: SLPSPostEventRecordToType?
+private var windowIsOrderedInPtr: SLSWindowIsOrderedInType?
 
 // Single-threaded-by-convention: focus paths run on main, so the lazy load
 // doesn't need a lock.
@@ -140,6 +147,20 @@ private func loadSkyLightFunctions() {
     if let symbol = dlsym(handle, "SLPSPostEventRecordTo") {
         postEventRecordPtr = unsafeBitCast(symbol, to: SLPSPostEventRecordToType.self)
     }
+    if let symbol = dlsym(handle, "SLSWindowIsOrderedIn") {
+        windowIsOrderedInPtr = unsafeBitCast(symbol, to: SLSWindowIsOrderedInType.self)
+    }
+}
+
+// Whether the window server has the window mapped on some Space — the only
+// signal that separates a live off-Space window from the stale entries
+// CGWindowListCopyWindowInfo keeps serving after a window closes.
+func SLSWindowIsOrderedIn(_ connection: CGSConnectionID, _ windowID: CGWindowID) -> Bool {
+    loadSkyLightFunctions()
+    guard let fn = windowIsOrderedInPtr else { return false }
+    var orderedIn = false
+    guard fn(connection, windowID, &orderedIn) == .success else { return false }
+    return orderedIn
 }
 
 @discardableResult

--- a/Docky/Services/WorkspaceService.swift
+++ b/Docky/Services/WorkspaceService.swift
@@ -127,10 +127,15 @@ final class WorkspaceService: ObservableObject {
         let isFrontmost = NSWorkspace.shared.frontmostApplication?.bundleIdentifier == bundleIdentifier
             && !runningApp.isHidden
 
-        // Running but no AX windows: spawn a new window.
-        if accessibilityGranted, allWindows.isEmpty,
-           let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
-            openApplication(at: appURL)
+        // No AX windows can also mean every window is on another Space (AX
+        // can't see those): activate to switch Spaces instead of reopening.
+        if accessibilityGranted, allWindows.isEmpty {
+            if hasWindowOnAnotherSpace(pid: runningApp.processIdentifier) {
+                runningApp.unhide()
+                runningApp.activateTransferringFrontmost(options: [.activateAllWindows])
+            } else if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
+                openApplication(at: appURL)
+            }
             return
         }
 
@@ -153,6 +158,25 @@ final class WorkspaceService: ObservableObject {
         // Default: bring the app forward.
         runningApp.unhide()
         runningApp.activateTransferringFrontmost(options: [.activateAllWindows])
+    }
+
+    /// Whether the window server knows a live, ordinary window for `pid` that
+    /// isn't on the active Space (ordered-in filters stale closed-window entries).
+    private func hasWindowOnAnotherSpace(pid: pid_t) -> Bool {
+        guard let entries = CGWindowListCopyWindowInfo([], kCGNullWindowID) as? [[String: Any]] else {
+            return false
+        }
+        let connection = CGSMainConnectionID()
+        return entries.contains { entry in
+            guard (entry[kCGWindowOwnerPID as String] as? pid_t) == pid,
+                  (entry[kCGWindowLayer as String] as? Int) == 0,
+                  ((entry[kCGWindowAlpha as String] as? Double) ?? 0) > 0,
+                  (entry[kCGWindowIsOnscreen as String] as? Bool) != true,
+                  let windowID = entry[kCGWindowNumber as String] as? CGWindowID else {
+                return false
+            }
+            return SLSWindowIsOrderedIn(connection, windowID)
+        }
     }
 
     private func applyFrontmostAppTileClickBehavior(


### PR DESCRIPTION
## Summary

Clicking a tile for an app whose windows all sit on another Space did nothing. Accessibility only reports windows on the active Space plus minimized ones, so the registry saw zero windows and the click fell into the "spawn a new window" path — a reopen that is a no-op for an app like Finder that already has a window open elsewhere, and one that never switches Spaces.

The no-windows branch now asks the window server first: if the app has a live, ordinary window off the active Space (layer 0, visible alpha, and ordered in — which filters the stale entries CGWindowListCopyWindowInfo keeps serving for closed windows), it activates the app instead, and macOS jumps to the Space holding its windows like the native Dock does. Genuinely windowless apps still get a fresh window.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [ ] Documentation
- [ ] Build / tooling / CI

## Related issues

Closes #66

## How was this tested?

- macOS version: 26.6.1
- Xcode version: 26.6
- Steps to reproduce / verify: with two desktops, open a Finder window on Desktop 2, switch to Desktop 1 with no Finder windows open or minimized there, and click the Finder tile — it should switch to Desktop 2 and focus the window. A standalone harness reproducing Docky's exact state confirmed the mechanism: the reopen path leaves the Space and frontmost app unchanged, while `activate(from:options:[.activateAllWindows])` switches to the window's Space and focuses the app; the SLPS path does neither for an off-Space window.

## Screenshots / recordings

No UI changes.

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
