### PR TITLE
fix(widgets): gate docky:// widget installs behind opt-in and pre-download consent

### DIFF
--- a/Docky/AppDelegate.swift
+++ b/Docky/AppDelegate.swift
@@ -228,9 +228,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         }
     }
 
-    /// `docky://install-widget?url=<downloadURL>` from the marketplace
-    /// website. Gated on Pro tier; surfaces an alert with the install
-    /// outcome so the user knows whether to restart Docky.
+    /// `docky://install-widget?url=<downloadURL>`. A widget is native code we
+    /// load in-process, so this path is off by default and confirmed before any
+    /// download, naming the source host. Manual installs stay open.
     private func handleInstallWidgetURL(_ url: URL) {
         guard
             let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -242,6 +242,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             presentInstallAlert(title: "Invalid widget install link", message: "The link did not include a valid HTTPS download URL.", style: .warning)
             return
         }
+
+        guard DockyPreferences.shared.allowsWidgetLinkInstalls else {
+            presentLinkInstallsDisabledAlert()
+            return
+        }
+
+        guard confirmLinkInstall(host: downloadURL.host ?? downloadString) else { return }
 
         Task { @MainActor in
             do {
@@ -266,6 +273,32 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                 )
             }
         }
+    }
+
+    /// Shown when a link install arrives while the feature is off. Sends the
+    /// user to the toggle rather than silently doing nothing.
+    private func presentLinkInstallsDisabledAlert() {
+        let alert = NSAlert()
+        alert.messageText = "Installing widgets from links is off"
+        alert.informativeText = "For safety, Docky won't install a widget from a link until you turn this on in Settings › Widget Store."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Open Settings")
+        alert.addButton(withTitle: "Cancel")
+        if alert.runModal() == .alertFirstButtonReturn {
+            SettingsNavigator.shared.requestPane(id: "externalWidgets")
+        }
+    }
+
+    /// Consent gate before any download. Cancel is the default button, so the
+    /// install is always a deliberate choice.
+    private func confirmLinkInstall(host: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Install a widget from “\(host)”?"
+        alert.informativeText = "Widgets are native plugins that run inside Docky with the same access Docky has — Accessibility, Automation, files, and more. Docky can't verify what a widget does. Only continue if you trust this source."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "Download & Install")
+        return alert.runModal() == .alertSecondButtonReturn
     }
 
     private func presentInstallAlert(title: String, message: String, style: NSAlert.Style) {

--- a/Docky/Services/DockyPreferences.swift
+++ b/Docky/Services/DockyPreferences.swift
@@ -1716,6 +1716,15 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         }
     }
 
+    /// Whether `docky://install-widget` links may install a widget. Off by
+    /// default so a web page can't drive a native-code install unprompted.
+    var allowsWidgetLinkInstalls: Bool {
+        didSet {
+            guard allowsWidgetLinkInstalls != oldValue else { return }
+            defaults.set(allowsWidgetLinkInstalls, forKey: Keys.allowsWidgetLinkInstalls)
+        }
+    }
+
     /// Whether app folders roll their contained apps' badges into a single
     /// total on the group tile, or paint a badge on each app icon. Only
     /// meaningful when `showsAppBadges` is on.
@@ -3548,6 +3557,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         static let windowSpaceBehavior = "docky.windowSpaceBehavior"
         static let autohidesWindow = "docky.autohidesWindow"
         static let showsAppBadges = "docky.showsAppBadges"
+        static let allowsWidgetLinkInstalls = "docky.allowsWidgetLinkInstalls"
         static let folderBadgeMode = "docky.folderBadgeMode"
         static let folderBadgePreviewStyle = "docky.folderBadgePreviewStyle"
         static let opensAtLogin = "docky.opensAtLogin"
@@ -3657,6 +3667,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         static let windowSpaceBehavior: DockWindowSpaceBehavior = .allSpaces
         static let autohidesWindow = false
         static let showsAppBadges = true
+        static let allowsWidgetLinkInstalls = false
         static let folderBadgeMode: FolderBadgeMode = .combined
         static let folderBadgePreviewStyle: FolderBadgePreviewStyle = .dot
         static let opensAtLogin = true
@@ -3789,6 +3800,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         let storedWindowSpaceBehavior = defaults.string(forKey: Keys.windowSpaceBehavior)
         let storedAutohidesWindow = defaults.object(forKey: Keys.autohidesWindow) as? Bool
         let storedShowsAppBadges = defaults.object(forKey: Keys.showsAppBadges) as? Bool
+        let storedAllowsWidgetLinkInstalls = defaults.object(forKey: Keys.allowsWidgetLinkInstalls) as? Bool
         let storedFolderBadgeMode = defaults.string(forKey: Keys.folderBadgeMode)
         let storedFolderBadgePreviewStyle = defaults.string(forKey: Keys.folderBadgePreviewStyle)
         let storedOpensAtLogin = defaults.object(forKey: Keys.opensAtLogin) as? Bool
@@ -3915,6 +3927,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         self.windowSpaceBehavior = (storedWindowSpaceBehavior.flatMap(DockWindowSpaceBehavior.init(rawValue:)) ?? DefaultValues.windowSpaceBehavior)
         self.autohidesWindow = storedAutohidesWindow ?? DefaultValues.autohidesWindow
         self.showsAppBadges = storedShowsAppBadges ?? DefaultValues.showsAppBadges
+        self.allowsWidgetLinkInstalls = storedAllowsWidgetLinkInstalls ?? DefaultValues.allowsWidgetLinkInstalls
         self.folderBadgeMode = storedFolderBadgeMode
             .flatMap(FolderBadgeMode.init(rawValue:))
             ?? DefaultValues.folderBadgeMode

--- a/Docky/Views/SettingsWindow/WidgetsSettingsView.swift
+++ b/Docky/Views/SettingsWindow/WidgetsSettingsView.swift
@@ -5,9 +5,8 @@
 //  Widget Store pane: browse the marketplace (community-submitted
 //  widgets fetched from getdocky.com/api/widgets), install
 //  `*.dockywidget` bundles from disk, and manage what's already
-//  installed. Loading external widget bundles is a Pro feature; users
-//  on the free tier see a Pro notice instead of the marketplace and
-//  installed lists.
+//  installed. Also owns the toggle that lets `docky://install-widget`
+//  links install a widget (off by default).
 //
 
 import AppKit
@@ -15,6 +14,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct WidgetsSettingsView: View {
+    @Bindable private var prefs = DockyPreferences.shared
     @State private var entries: [WidgetEntry] = []
     @State private var marketplaceState: MarketplaceState = .loading
     @State private var hasPendingChanges = false
@@ -79,6 +79,13 @@ struct WidgetsSettingsView: View {
                     }
                 }
             }
+        }
+
+        Section("Security") {
+            Toggle("Allow installing widgets from links", isOn: $prefs.allowsWidgetLinkInstalls)
+            Text("Links like `docky://install-widget` let a web page install a widget. Off by default. Widgets are native plugins that run inside Docky with the same access Docky has — Accessibility, Automation, files, and more — and Docky doesn't sandbox or verify them, so only install widgets you trust. Installing a `.dockywidget` file yourself always works.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
 
         Section("Marketplace") {


### PR DESCRIPTION
## Summary

`docky://install-widget?url=…` let a web page install and load a native
widget bundle. Widget bundles are loaded in-process via `Bundle.load()`, so
they run with everything Docky is trusted for (Accessibility, Automation,
Calendar, Reminders, Location, and broad filesystem access), while the handler
only checked that the download was HTTPS. There was no opt-in and no consent
step, so a single click on a page could drive a code-execution path behind a
benign-looking "Widget installed" alert that appeared after the bundle was
already on disk.

This keeps widgets open for people to build their own, so there is no Team-ID
signature pinning. Instead it defends the part that was actually dangerous, a
page driving the install. Three changes:

- **Link installs off by default.** New `DockyPreferences.allowsWidgetLinkInstalls`
  (default `false`). When off, a `docky://install-widget` link raises an alert
  that opens Settings › Widget Store on the right pane instead of downloading
  anything. This is the main control, and it closes the drive-by for anyone who
  never opted in. It is deliberately left out of the reset-to-defaults paths so
  an unrelated "reset" cannot silently flip a security setting.
- **Consent before download.** When link installs are on, the handler shows a
  confirmation naming the source host, with **Cancel as the default button**,
  before any network request or quarantine stripping happens. The install only
  proceeds on an explicit choice.
- **Honest limitations in the UI.** The Widget Store pane gains a Security
  section with the toggle and plain copy that says widgets are native plugins
  running in-process with Docky's access, not sandboxed and not verified.

Manual `.dockywidget` installs (file picker and marketplace) are unchanged,
since choosing the file is the consent there. The marketplace path still
verifies SHA-256 when the manifest provides one. No host allowlist or required
SHA was added to the bare-URL link path on purpose. There is no signed manifest
to source a hash from, and a fixed allowlist would break self-hosted widgets,
which is the whole point of keeping widgets open. The host-named consent dialog
is the host-awareness control instead.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [ ] Documentation
- [ ] Build / tooling / CI

## Related issues

Closes #65

## How was this tested?

- macOS version: 26.6.1
- Xcode version: 26.6
- Steps to reproduce / verify:
  1. With the toggle at its default (off), trigger
     `docky://install-widget?url=https://example.com/x.dockywidget`. The
     "installing from links is off" alert appears, and "Open Settings" lands on
     Widget Store. Nothing is downloaded.
  2. Enable **Allow installing widgets from links** in Settings › Widget Store,
     then trigger the link again. A host-named confirmation appears. Return or
     Cancel aborts with no download, "Download & Install" proceeds.
  3. With the toggle off, Settings › Widget Store, "Install from File…" still
     installs a local `.dockywidget`.

The `Docky` scheme builds clean (`xcodebuild … build` reports
`** BUILD SUCCEEDED **`). The `docky://` scheme routes through LaunchServices,
so the link steps are verified by hand rather than scripted.

## Screenshots / recordings

<!-- TODO: add before/after of the Widget Store Security section and the two alerts. -->

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [ ] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
