### PR TITLE
fix(dock): move dragged files to the Trash when dropped on the trash tile

### DIFF
--- a/Docky/Services/AppleScriptService.swift
+++ b/Docky/Services/AppleScriptService.swift
@@ -5,12 +5,24 @@
 //  Finder-backed actions that are awkward or unavailable via NSWorkspace
 //  alone. Scripts are executed directly from source at runtime.
 //
+//  Scripts must never run on the main thread: sending an Apple Event to a
+//  target the user hasn't authorized yet blocks the sending thread until the
+//  TCC consent prompt is answered (or the event times out after ~2 minutes).
+//  On the main thread that freezes the entire dock — observed on the first
+//  ever Trash-tile click, where "open trash" stalled behind the pending
+//  "Docky wants to control Finder" prompt. All executions go through one
+//  serial queue: each call builds a fresh NSAppleScript instance, and the
+//  queue keeps executions from overlapping since NSAppleScript makes no
+//  thread-safety guarantees.
+//
 
 import AppKit
 import Foundation
 
 final class AppleScriptService {
     static let shared = AppleScriptService()
+
+    private let scriptQueue = DispatchQueue(label: "gt.quintero.Docky.applescript", qos: .userInitiated)
 
     private init() {}
 
@@ -37,6 +49,19 @@ final class AppleScriptService {
         return result
     }
 
+    private func executeOnScriptQueue(source: String) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            scriptQueue.async {
+                do {
+                    _ = try self.executeDescriptor(source: source)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
     @discardableResult
     func runCatalogScript(
         source: String,
@@ -45,7 +70,7 @@ final class AppleScriptService {
         targetApp: String?
     ) async -> Result<Void, AppleScriptServiceError> {
         do {
-            try execute(source: source)
+            try await executeOnScriptQueue(source: source)
             permissionRequirements.forEach { permission in
                 updateGrantedPermission(permission)
             }
@@ -111,7 +136,7 @@ final class AppleScriptService {
 
     private func runFinderScript(_ command: FinderCommand) async -> Bool {
         do {
-            try await MainActor.run { try execute(source: command.source) }
+            try await executeOnScriptQueue(source: command.source)
             PermissionsService.shared.updateFinderAutomation(status: .granted)
             return true
         } catch let error as AppleScriptServiceError {
@@ -125,7 +150,7 @@ final class AppleScriptService {
 
     private func runSystemEventsPermissionProbe() async -> Bool {
         do {
-            try await MainActor.run { try execute(source: SystemEventsCommand.permissionProbe.source) }
+            try await executeOnScriptQueue(source: SystemEventsCommand.permissionProbe.source)
             PermissionsService.shared.updateSystemEventsAutomation(status: .granted)
             return true
         } catch let error as AppleScriptServiceError {
@@ -135,10 +160,6 @@ final class AppleScriptService {
             handleSystemEventsPermissionProbe(.executionFailed(error.localizedDescription))
             return false
         }
-    }
-
-    private func execute(source: String) throws {
-        _ = try executeDescriptor(source: source)
     }
 
     private func scriptError(from errorInfo: NSDictionary?) -> AppleScriptServiceError? {
@@ -245,12 +266,16 @@ final class AppleScriptService {
         }
     }
 
+    // Error handlers run on whatever thread the script path finished on;
+    // NSAlert is main-thread only, so both alert helpers hop explicitly.
     private func presentAlert(title: String, body: String) {
-        let alert = NSAlert()
-        alert.messageText = title
-        alert.informativeText = body
-        alert.alertStyle = .warning
-        alert.runModal()
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = title
+            alert.informativeText = body
+            alert.alertStyle = .warning
+            alert.runModal()
+        }
     }
 
     private func presentAutomationAlert(
@@ -258,6 +283,16 @@ final class AppleScriptService {
         actionTitle: String,
         includesSystemEvents: Bool
     ) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async {
+                self.presentAutomationAlert(
+                    targetApp: targetApp,
+                    actionTitle: actionTitle,
+                    includesSystemEvents: includesSystemEvents
+                )
+            }
+            return
+        }
         let alert = NSAlert()
         alert.messageText = String(localized: "Automation wasn’t allowed")
         let appName = displayName(for: targetApp)

--- a/Docky/Views/MainWindow/MainWindowView.swift
+++ b/Docky/Views/MainWindow/MainWindowView.swift
@@ -465,15 +465,22 @@ final class ClickThroughHostingView: NSHostingView<MainWindowView> {
                 return true
             case .document(let urls):
                 guard let targetTileID,
-                      let bundleIdentifier = TileStore.shared.tiles
-                        .first(where: { $0.id == targetTileID })
-                        .flatMap({ tile -> String? in
-                            if case .app(let app) = tile.content { return app.bundleIdentifier }
-                            return nil
-                        }) else {
+                      let targetTile = TileStore.shared.tiles.first(where: { $0.id == targetTileID }) else {
                     return false
                 }
-                WorkspaceService.shared.open(fileURLs: urls, withApplicationBundleIdentifier: bundleIdentifier)
+                if case .trash = targetTile.content {
+                    // Returning false when nothing was trashed keeps the
+                    // system's slide-back animation as the failure cue.
+                    var trashedAny = false
+                    for url in urls where (try? FileManager.default.trashItem(at: url, resultingItemURL: nil)) != nil {
+                        trashedAny = true
+                    }
+                    return trashedAny
+                }
+                guard case .app(let app) = targetTile.content, !app.bundleIdentifier.isEmpty else {
+                    return false
+                }
+                WorkspaceService.shared.open(fileURLs: urls, withApplicationBundleIdentifier: app.bundleIdentifier)
                 return true
             }
         }

--- a/Docky/Views/Tiles/TileContainerView.swift
+++ b/Docky/Views/Tiles/TileContainerView.swift
@@ -216,11 +216,13 @@ struct TileContainerView: View {
         // when the dock is content-sized.
         let isFlexible = tile.content == .flexibleSpacer
         let isHorizontal = !position.isVertical
+        let isTrashTile = tile.content == .trash
         TileView(
             tile: tile,
-            isDocumentDropTarget: dockDrag.documentTargetTileID == tile.id,
+            isDocumentDropTarget: !isTrashTile && dockDrag.documentTargetTileID == tile.id,
             isAppFolderDropTarget: draggedAppFolderTargetTileID == tile.id,
-            isTrashDropTarget: draggedTrashTargetTileID == tile.id,
+            isTrashDropTarget: draggedTrashTargetTileID == tile.id
+                || (isTrashTile && dockDrag.documentTargetTileID == tile.id),
             renderedTileSize: iconSize
         )
             .frame(
@@ -1647,7 +1649,11 @@ struct TileContainerView: View {
         let positionValue = projected(point: location)
         switch kind {
         case .document:
+            // Documents can target an app tile (open-with) or the Trash tile
+            // (move to trash). Without the trash fallback the drop lands with
+            // no target and performDragOperation silently rejects it.
             let targetID = documentDropTargetTileID(at: location)
+                ?? trashDropTargetTileID(at: location, sourceTileID: "")
             if dockDrag.documentTargetTileID != targetID { dockDrag.documentTargetTileID = targetID }
             if dockDrag.destinationIndex != nil { dockDrag.destinationIndex = nil }
             if dockDrag.destinationSection != nil { dockDrag.destinationSection = nil }


### PR DESCRIPTION
## Summary

Dragging a file from a dock folder (such as Downloads) onto the Trash tile showed the green plus cursor but the drop did nothing. The drop was advertised without being handled: `draggingUpdated` returns `.copy` whenever an external drag is over the dock, but the document target resolver only ever matched app tiles for open-with, so over the Trash tile the target stayed nil and `performDragOperation` rejected the drop.

The fix makes the Trash tile a real document drop target. During a document drag the resolver now falls back to the existing trash hit test, the tile gets the trash hover highlight, and the drop handler moves each URL to the Trash with `FileManager.trashItem`. The handler returns false when nothing was trashed so the system slide-back animation remains the failure cue.

While verifying, the first ever Trash tile click froze the whole dock. Cause: Finder scripts ran through `NSAppleScript.executeAndReturnError` on the main thread, and an Apple Event to a target the user has not yet authorized blocks the sending thread until the TCC consent prompt is answered or the event times out after about 2 minutes. All script execution now goes through a serial background queue, so consent prompts and slow Finder replies no longer freeze the dock. The error alerts also now hop to the main thread explicitly, since some paths already invoked `NSAlert.runModal` from non-main contexts.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [ ] Documentation
- [ ] Build / tooling / CI

## Related issues

Closes #56

## How was this tested?

- macOS version: 26.6.1
- Xcode version: 26.6
- Steps to reproduce / verify:
  1. A standalone harness confirmed `FileManager.trashItem` moves a file from `~/Downloads` into `~/.Trash` cleanly.
  2. In the debug build, dragged a file from the Downloads popover onto the Trash tile: the tile highlights on hover and the file lands in the Trash, with the Trash icon flipping to full via the existing directory watcher.
  3. Clicked the Trash tile with no Finder automation grant present (verified against the TCC database): the dock stays responsive while the consent prompt is up, and after approving, the Trash window opens.

## Screenshots / recordings

Not applicable, behavior is drag and drop plus a consent prompt.

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
