### PR TITLE
feat(dock): add toggle to dim idle app icons when hidden or windowless

### DIFF
--- a/Docky/Services/DockyPreferences.swift
+++ b/Docky/Services/DockyPreferences.swift
@@ -1716,6 +1716,16 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         }
     }
 
+    /// Whether app tiles fade to half opacity while their app is idle —
+    /// hidden (Cmd+H) or running with no windows open. Off keeps icons
+    /// fully opaque regardless of state.
+    var dimsIdleAppIcons: Bool {
+        didSet {
+            guard dimsIdleAppIcons != oldValue else { return }
+            defaults.set(dimsIdleAppIcons, forKey: Keys.dimsIdleAppIcons)
+        }
+    }
+
     /// Whether app folders roll their contained apps' badges into a single
     /// total on the group tile, or paint a badge on each app icon. Only
     /// meaningful when `showsAppBadges` is on.
@@ -3548,6 +3558,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         static let windowSpaceBehavior = "docky.windowSpaceBehavior"
         static let autohidesWindow = "docky.autohidesWindow"
         static let showsAppBadges = "docky.showsAppBadges"
+        static let dimsIdleAppIcons = "docky.dimsIdleAppIcons"
         static let folderBadgeMode = "docky.folderBadgeMode"
         static let folderBadgePreviewStyle = "docky.folderBadgePreviewStyle"
         static let opensAtLogin = "docky.opensAtLogin"
@@ -3657,6 +3668,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         static let windowSpaceBehavior: DockWindowSpaceBehavior = .allSpaces
         static let autohidesWindow = false
         static let showsAppBadges = true
+        static let dimsIdleAppIcons = false
         static let folderBadgeMode: FolderBadgeMode = .combined
         static let folderBadgePreviewStyle: FolderBadgePreviewStyle = .dot
         static let opensAtLogin = true
@@ -3789,6 +3801,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         let storedWindowSpaceBehavior = defaults.string(forKey: Keys.windowSpaceBehavior)
         let storedAutohidesWindow = defaults.object(forKey: Keys.autohidesWindow) as? Bool
         let storedShowsAppBadges = defaults.object(forKey: Keys.showsAppBadges) as? Bool
+        let storedDimsIdleAppIcons = defaults.object(forKey: Keys.dimsIdleAppIcons) as? Bool
         let storedFolderBadgeMode = defaults.string(forKey: Keys.folderBadgeMode)
         let storedFolderBadgePreviewStyle = defaults.string(forKey: Keys.folderBadgePreviewStyle)
         let storedOpensAtLogin = defaults.object(forKey: Keys.opensAtLogin) as? Bool
@@ -3915,6 +3928,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         self.windowSpaceBehavior = (storedWindowSpaceBehavior.flatMap(DockWindowSpaceBehavior.init(rawValue:)) ?? DefaultValues.windowSpaceBehavior)
         self.autohidesWindow = storedAutohidesWindow ?? DefaultValues.autohidesWindow
         self.showsAppBadges = storedShowsAppBadges ?? DefaultValues.showsAppBadges
+        self.dimsIdleAppIcons = storedDimsIdleAppIcons ?? DefaultValues.dimsIdleAppIcons
         self.folderBadgeMode = storedFolderBadgeMode
             .flatMap(FolderBadgeMode.init(rawValue:))
             ?? DefaultValues.folderBadgeMode
@@ -4188,6 +4202,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         // Visibility
         autohidesWindow = DefaultValues.autohidesWindow
         showsAppBadges = DefaultValues.showsAppBadges
+        dimsIdleAppIcons = DefaultValues.dimsIdleAppIcons
         folderBadgeMode = DefaultValues.folderBadgeMode
         folderBadgePreviewStyle = DefaultValues.folderBadgePreviewStyle
         autohideWindowDelay = DefaultValues.autohideWindowDelay
@@ -4247,6 +4262,7 @@ enum LaunchpadSortMode: String, CaseIterable, Codable, Identifiable {
         windowSpaceBehavior = DefaultValues.windowSpaceBehavior
         autohidesWindow = DefaultValues.autohidesWindow
         showsAppBadges = DefaultValues.showsAppBadges
+        dimsIdleAppIcons = DefaultValues.dimsIdleAppIcons
         folderBadgeMode = DefaultValues.folderBadgeMode
         folderBadgePreviewStyle = DefaultValues.folderBadgePreviewStyle
         opensAtLogin = DefaultValues.opensAtLogin

--- a/Docky/Views/SettingsWindow/BehaviorSettingsView.swift
+++ b/Docky/Views/SettingsWindow/BehaviorSettingsView.swift
@@ -327,6 +327,16 @@ struct BehaviorSettingsView: View {
             .padding(.vertical, 4)
 
             VStack(alignment: .leading, spacing: 8) {
+                Toggle("Dim Idle App Icons", isOn: $preferences.dimsIdleAppIcons)
+                    .font(.headline)
+
+                Text("Fades an app's tile to half opacity while the app is hidden or has no windows open. Turn off to keep icons fully opaque regardless of state. Detecting open windows needs Accessibility permission.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 4)
+
+            VStack(alignment: .leading, spacing: 8) {
                 Toggle("Show Notification Badges", isOn: $preferences.showsAppBadges)
                     .font(.headline)
 

--- a/Docky/Views/Tiles/AppTileView.swift
+++ b/Docky/Views/Tiles/AppTileView.swift
@@ -18,6 +18,7 @@ struct AppTileView: View {
     var iconOverridePaddingFraction: CGFloat? = nil
     @Bindable private var preferences = DockyPreferences.shared
     @ObservedObject private var workspace = WorkspaceService.shared
+    @ObservedObject private var windowRegistry = WindowRegistry.shared
 
     private var isRunning: Bool {
         workspace.isRunning(bundleIdentifier: tile.bundleIdentifier)
@@ -25,6 +26,18 @@ struct AppTileView: View {
 
     private var isHidden: Bool {
         workspace.isHidden(bundleIdentifier: tile.bundleIdentifier)
+    }
+
+    /// Idle = running with no windows left open. Only trustworthy with
+    /// Accessibility granted — without it the registry is empty and every
+    /// running app would read as windowless.
+    private var isIdle: Bool {
+        guard isRunning, PermissionsService.shared.accessibility == .granted else { return false }
+        return windowRegistry.windows(forBundleIdentifier: tile.bundleIdentifier).isEmpty
+    }
+
+    private var isDimmed: Bool {
+        preferences.dimsIdleAppIcons && (isHidden || isIdle)
     }
 
     var body: some View {
@@ -73,7 +86,7 @@ struct AppTileView: View {
                 .interpolation(.high)
                 .aspectRatio(contentMode: shouldApplyCircleClip ? .fill : .fit)
                 .padding(pad)
-                .opacity(isHidden ? 0.5 : 1)
+                .opacity(isDimmed ? 0.5 : 1)
         } else {
             let inset = shouldApplyCircleClip ? transparencyCompensationInset + 2 : 0
             let edgeInsets: CGFloat = hasOverride ? -transparencyCompensationInset * 4 : inset
@@ -84,7 +97,7 @@ struct AppTileView: View {
                 .aspectRatio(contentMode: shouldApplyCircleClip ? .fill : .fit)
                 .frame(width: size.width + edgeInsets / 2, height: size.height + edgeInsets / 2)
                 .frame(width: size.width - edgeInsets * 2, height: size.height - edgeInsets * 2)
-                .opacity(isHidden ? 0.5 : 1)
+                .opacity(isDimmed ? 0.5 : 1)
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a "Dim Idle App Icons" toggle (Settings > Behavior) so users can choose whether app tiles fade when their app is idle, as requested in #55.

Previously the half-opacity dim applied only to apps hidden with Cmd+H. This PR defines idle as "running with no windows open" and dims those tiles too, driven by `WindowRegistry`'s published window list. The windowless check is gated on Accessibility permission: without it the registry is empty and every running app would falsely read as idle. Turning the toggle off keeps icons fully opaque in every state.

The preference (`dimsIdleAppIcons`) defaults to off, so icons stay fully opaque until the user opts in. Note this also turns off the pre-existing hidden-app dim by default. Storage follows the same pattern as `showsAppBadges` in `DockyPreferences`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / performance (no functional change)
- [ ] Documentation
- [ ] Build / tooling / CI

## Related issues

Closes #55

## How was this tested?

- macOS version: 26.6.1
- Xcode version: 26.6
- Steps to reproduce / verify:
  1. Run Docky with Accessibility granted and open an app with one window. With the toggle off (default), the tile stays fully opaque when the app is hidden or windowless.
  2. Turn on Settings > Behavior > "Dim Idle App Icons".
  3. Close the app's last window without quitting: the tile fades to half opacity.
  4. Reopen a window: the tile returns to full opacity.
  5. Hide the app with Cmd+H: the tile fades as well.

## Screenshots / recordings

## Checklist

- [x] The `Docky` scheme builds without new warnings.
- [x] I tested the change on macOS 14.0 or later.
- [x] I granted/verified any required Accessibility and Screen Recording permissions where relevant.
- [x] Commit messages follow the `type(scope): summary` convention used in this repo.
- [x] I updated documentation (README, comments) where needed.
- [x] My changes are licensed under GPLv3, consistent with the rest of the project.
